### PR TITLE
[ENHANCEMENT] Extract Logger abstraction — remove raw Timber from domain layer

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/useCaseModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/useCaseModule.kt
@@ -30,22 +30,30 @@ import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetNonRecu
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetNonRecurringIncomeTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetRecurringExpenseTemplatesUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetRecurringIncomeTransactionsUseCase
+import fr.laforge.benoist.financialmanager.domain.util.Logger
+import fr.laforge.benoist.financialmanager.infrastructure.logging.TimberLogger
 import fr.laforge.benoist.financialmanager.infrastructure.usecase.EnableNotificationAccessUseCaseImpl
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
 val useCaseModule by lazy {
     module {
+        // Logging — single TimberLogger instance shared across all use cases
+        single<Logger> { TimberLogger() }
+
         factoryOf(::ExportTransactionsListUseCase)
         factoryOf(::GetAllTransactionsUseCase)
         factoryOf(::GetAllRecurringTransactionsUseCase)
         factory<CreateTransactionUseCase> { CreateTransactionUseCaseImpl(repository = get()) }
-        factory<CreateRegularTransactionsUseCase> { CreateRegularTransactionsUseCaseImpl(repository = get()) }
+        factory<CreateRegularTransactionsUseCase> {
+            CreateRegularTransactionsUseCaseImpl(repository = get(), logger = get())
+        }
         factory<EnableNotificationAccessUseCase> { EnableNotificationAccessUseCaseImpl(context = get()) }
         factory {
             CreateTransactionFromNotificationUseCase(
                 createTransactionUseCase = get(),
                 notificationHelper = get(),
+                logger = get(),
             )
         }
 
@@ -116,7 +124,8 @@ val useCaseModule by lazy {
 
         factory {
             GetNonRecurringExpenseTransactionsUseCase(
-                repository = get()
+                repository = get(),
+                logger = get()
             )
         }
 

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CreateRegularTransactionsUseCaseImpl.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CreateRegularTransactionsUseCaseImpl.kt
@@ -4,8 +4,8 @@ import fr.laforge.benoist.financialmanager.domain.util.isInRange
 import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionPeriod
 import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
 import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
+import fr.laforge.benoist.financialmanager.domain.util.Logger
 import kotlinx.coroutines.flow.first
-import timber.log.Timber
 import java.time.LocalDateTime
 
 /**
@@ -16,9 +16,12 @@ import java.time.LocalDateTime
  *
  * @property repository The [FinancialRepository] used to read templates and persist
  *   generated child transactions.
+ * @property logger Domain [Logger] for diagnostic output. Defaults to [Logger.NoOp]
+ *   so callers (including tests) are never forced to supply one.
  */
 class CreateRegularTransactionsUseCaseImpl(
-    private val repository: FinancialRepository
+    private val repository: FinancialRepository,
+    private val logger: Logger = Logger.NoOp
 ) : CreateRegularTransactionsUseCase {
 
     override suspend fun execute(
@@ -29,10 +32,9 @@ class CreateRegularTransactionsUseCaseImpl(
     ): Boolean {
         val transactions = repository.getAllPeriodicTransactions().first()
 
-        Timber.d("startDate: $startDate")
-        Timber.d("endDate: $endDate")
-
-        Timber.d("$transactions")
+        logger.debug("startDate: $startDate")
+        logger.debug("endDate: $endDate")
+        logger.debug("$transactions")
 
         transactions.forEach { transaction ->
 
@@ -42,10 +44,10 @@ class CreateRegularTransactionsUseCaseImpl(
                 endDate = endDate
             )
 
-            Timber.d("Children transactions: $childrenTransactions")
+            logger.debug("Children transactions: $childrenTransactions")
 
             if (childrenTransactions.isEmpty()) {
-                Timber.d("No children transactions, let's create them")
+                logger.debug("No children transactions, let's create them")
                 var date = LocalDateTime.of(
                     currentDate.year,
                     currentDate.monthValue,
@@ -55,20 +57,18 @@ class CreateRegularTransactionsUseCaseImpl(
                 )
 
                 if (!date.isInRange(startDate, endDate)) {
-                    Timber.d("Task is not in date range")
+                    logger.debug("Task is not in date range")
                     var month = currentDate.monthValue
                     var year = currentDate.year
                     if (date > endDate) {
-                        Timber.d("date > endDate")
-                        Timber.d("date:$date")
-                        Timber.d("endDate:$endDate")
+                        logger.debug("date > endDate — date:$date endDate:$endDate")
                         month -= 1
                         if (month == JANUARY - 1) {
                             month = DECEMBER
                             year -= 1
                         }
                     } else {
-                        Timber.d("date <= endDate")
+                        logger.debug("date <= endDate")
                         month += 1
                         if (month == DECEMBER + 1) {
                             month = JANUARY
@@ -85,7 +85,7 @@ class CreateRegularTransactionsUseCaseImpl(
                     )
                 }
 
-                Timber.d("Creating Transaction: ${
+                logger.debug("Creating Transaction: ${
                     transaction.copy(
                         uid = 0,
                         isPeriodic = false,

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/CreateTransactionFromNotificationUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/CreateTransactionFromNotificationUseCase.kt
@@ -1,17 +1,30 @@
 package fr.laforge.benoist.financialmanager.domain.usecase.notification
 
 import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
-import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRemainingBalanceUseCase
+import fr.laforge.benoist.financialmanager.domain.util.Logger
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 
+/**
+ * Use case that creates a [Transaction] from an incoming notification payload.
+ *
+ * Orchestrates notification validation, parsing, and persistence by delegating
+ * to [NotificationHelper] and [CreateTransactionUseCase]. Returns `true` when
+ * a transaction was successfully created, `false` for any non-fatal failure
+ * (unrecognised notification, parse error).
+ *
+ * @property createTransactionUseCase Persists the parsed transaction.
+ * @property notificationHelper Validates and parses the raw notification strings.
+ * @property dispatcher Coroutine dispatcher for the blocking parse/persist work.
+ *   Defaults to [Dispatchers.IO]; override in tests for determinism.
+ * @property logger Domain [Logger] for diagnostic output. Defaults to [Logger.NoOp].
+ */
 class CreateTransactionFromNotificationUseCase(
     private val createTransactionUseCase: CreateTransactionUseCase,
     private val notificationHelper: NotificationHelper,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val logger: Logger = Logger.NoOp,
 ) {
     suspend operator fun invoke(notificationTitle: String, notificationMessage: String): Boolean =
         withContext(dispatcher) {
@@ -21,7 +34,7 @@ class CreateTransactionFromNotificationUseCase(
                 .getOrDefault(false)
 
             if (!isTransaction) {
-                Timber.e("Not a valid transaction")
+                logger.error("Not a valid transaction")
                 return@withContext false
             }
 
@@ -34,8 +47,10 @@ class CreateTransactionFromNotificationUseCase(
             // 3. Guard Clause: Check if parsing succeeded
             val transaction = transactionResult.getOrNull()
             if (transaction == null) {
-                // Log the actual error from the Result for debugging
-                Timber.e(transactionResult.exceptionOrNull(), "Failed to parse transaction")
+                logger.error(
+                    message = "Failed to parse transaction",
+                    throwable = transactionResult.exceptionOrNull()
+                )
                 return@withContext false
             }
 

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetNonRecurringExpenseTransactionsUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetNonRecurringExpenseTransactionsUseCase.kt
@@ -4,9 +4,9 @@ import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
 import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionFilter
 import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
 import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
+import fr.laforge.benoist.financialmanager.domain.util.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import timber.log.Timber
 import java.time.LocalDateTime
 
 /**
@@ -16,8 +16,12 @@ import java.time.LocalDateTime
  * fixed monthly bills. It is used to analyze discretionary spending.
  *
  * @property repository The [FinancialRepository] source of truth.
+ * @property logger Domain [Logger] for diagnostic output. Defaults to [Logger.NoOp].
  */
-class GetNonRecurringExpenseTransactionsUseCase(private val repository: FinancialRepository) {
+class GetNonRecurringExpenseTransactionsUseCase(
+    private val repository: FinancialRepository,
+    private val logger: Logger = Logger.NoOp
+) {
 
     /**
      * Retrieves a stream of non-recurring expense transactions for the month of the given [date].
@@ -34,7 +38,7 @@ class GetNonRecurringExpenseTransactionsUseCase(private val repository: Financia
      * @return A [Flow] emitting the filtered and sorted list of [Transaction] objects.
      */
     operator fun invoke(date: LocalDateTime = LocalDateTime.now()): Flow<List<Transaction>> {
-        Timber.i("Fetching non-recurring expense transactions for the month of $date")
+        logger.info("Fetching non-recurring expense transactions for the month of $date")
 
         return repository.getTransactions(
             filter = TransactionFilter.monthlyVariableExpenses(date)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/util/Logger.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/util/Logger.kt
@@ -1,0 +1,50 @@
+package fr.laforge.benoist.financialmanager.domain.util
+
+/**
+ * Domain-level logging abstraction.
+ *
+ * The domain layer must not depend on any framework-specific logging solution
+ * (e.g. Timber, Log). This interface allows use cases to emit diagnostic
+ * messages without coupling the domain to an Android library.
+ *
+ * @note Implementations live in the infrastructure layer (e.g. TimberLogger).
+ * The [NoOp] singleton is the safe default for tests and any context where
+ * logging is not required — callers never need to null-check the logger.
+ */
+interface Logger {
+
+    /**
+     * Emits a debug-level message, intended for verbose diagnostic output.
+     *
+     * @param message The message to log.
+     */
+    fun debug(message: String)
+
+    /**
+     * Emits an info-level message, intended for significant lifecycle events.
+     *
+     * @param message The message to log.
+     */
+    fun info(message: String)
+
+    /**
+     * Emits an error-level message, optionally associating a [Throwable].
+     *
+     * @param message A human-readable description of the error.
+     * @param throwable The exception that caused the error, if available.
+     */
+    fun error(message: String, throwable: Throwable? = null)
+
+    /**
+     * A no-operation [Logger] implementation.
+     *
+     * Used as the default value in use case constructors so that callers
+     * (especially tests) are never forced to provide a logger explicitly.
+     * All methods discard their arguments silently.
+     */
+    object NoOp : Logger {
+        override fun debug(message: String) = Unit
+        override fun info(message: String) = Unit
+        override fun error(message: String, throwable: Throwable?) = Unit
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/logging/TimberLogger.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/logging/TimberLogger.kt
@@ -1,0 +1,45 @@
+package fr.laforge.benoist.financialmanager.infrastructure.logging
+
+import fr.laforge.benoist.financialmanager.domain.util.Logger
+import timber.log.Timber
+
+/**
+ * Infrastructure implementation of [Logger] backed by Timber.
+ *
+ * Timber is an Android-specific logging library and must never be imported
+ * in the domain layer. This class acts as the boundary adapter, translating
+ * domain-level log calls into the appropriate Timber equivalents.
+ *
+ * @note Timber must be planted (via [Timber.plant]) before this logger is
+ * used. Planting is performed in [FinancialManagerApp] at application startup.
+ */
+class TimberLogger : Logger {
+
+    /**
+     * Delegates to [Timber.d] for verbose diagnostic output.
+     *
+     * @param message The message to log.
+     */
+    override fun debug(message: String) {
+        Timber.d(message)
+    }
+
+    /**
+     * Delegates to [Timber.i] for significant lifecycle events.
+     *
+     * @param message The message to log.
+     */
+    override fun info(message: String) {
+        Timber.i(message)
+    }
+
+    /**
+     * Delegates to [Timber.e] for error-level output.
+     *
+     * @param message A human-readable description of the error.
+     * @param throwable The exception that caused the error, if available.
+     */
+    override fun error(message: String, throwable: Throwable?) {
+        Timber.e(throwable, message)
+    }
+}


### PR DESCRIPTION
## Summary
Closes #4

Three domain use cases imported `timber.log.Timber` directly — a violation of the **Zero Framework Policy**. Timber is an Android-specific library and must not exist in the domain layer.

## Changes

### New: `domain/util/Logger.kt`
A pure-Kotlin interface with `debug()`, `info()`, and `error()` methods, plus a built-in `NoOp` singleton. The NoOp is the constructor default for all affected use cases, meaning **no existing test needed modification**.

### New: `infrastructure/logging/TimberLogger.kt`
Infrastructure-layer adapter that delegates each `Logger` method to the appropriate `Timber` level. Registered as a Koin `single<Logger>` in `useCaseModule`.

### Modified use cases
| Class | Timber calls replaced |
|-------|-----------------------|
| `CreateRegularTransactionsUseCaseImpl` | 10 × `Timber.d` |
| `GetNonRecurringExpenseTransactionsUseCase` | 1 × `Timber.i` |
| `CreateTransactionFromNotificationUseCase` | 2 × `Timber.e` |

## Checklist
- [x] Zero Framework Policy respected — no `timber.*` in domain
- [x] `Logger.NoOp` default keeps all existing tests passing without changes
- [x] `TimberLogger` contained entirely in infrastructure layer
- [x] Full KDoc on both new classes
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)