### PR TITLE
[SMELL] Unify CreateTransactionUseCase API (issue #14)

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CreateTransactionUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CreateTransactionUseCase.kt
@@ -1,12 +1,13 @@
 package fr.laforge.benoist.financialmanager.domain.usecase
 
 import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
-import kotlinx.coroutines.flow.Flow
 
 interface CreateTransactionUseCase {
-    fun execute(
-        transaction: Transaction
-    ): Flow<Boolean>
-
-    operator fun invoke(transaction: Transaction): Boolean
+    /**
+     * Persists a new transaction in the repository.
+     *
+     * @param transaction The transaction to create.
+     * @return True if the transaction was successfully created.
+     */
+    suspend operator fun invoke(transaction: Transaction): Boolean
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CreateTransactionUseCaseImpl.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CreateTransactionUseCaseImpl.kt
@@ -2,7 +2,6 @@ package fr.laforge.benoist.financialmanager.domain.usecase
 
 import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
 import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
-import kotlinx.coroutines.flow.flow
 
 /**
  * Default implementation of [CreateTransactionUseCase].
@@ -17,9 +16,7 @@ class CreateTransactionUseCaseImpl(
     private val repository: FinancialRepository
 ) : CreateTransactionUseCase {
 
-    override fun execute(
-        transaction: Transaction
-    ) = flow {
+    override suspend fun invoke(transaction: Transaction): Boolean {
         // Creates transaction
         val id = repository.createTransaction(
             transaction
@@ -28,25 +25,7 @@ class CreateTransactionUseCaseImpl(
         // If transaction is periodic, creates the associated regular transaction for the current
         // period
         if (transaction.isPeriodic) {
-            val regularTransaction = transaction.copy(isPeriodic = false, parent = id.toInt())
-            repository.createTransaction(
-                regularTransaction
-            )
-        }
-
-        emit(true)
-    }
-
-    override fun invoke(transaction: Transaction): Boolean {
-        // Creates transaction
-        val id = repository.createTransaction(
-            transaction
-        )
-
-        // If transaction is periodic, creates the associated regular transaction for the current
-        // period
-        if (transaction.isPeriodic) {
-            val regularTransaction = transaction.copy(isPeriodic = false, parent = id.toInt())
+            val regularTransaction = transaction.copy(uid = 0, isPeriodic = false, parent = id.toInt())
             repository.createTransaction(
                 regularTransaction
             )

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/add/AddTransactionViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/add/AddTransactionViewModel.kt
@@ -88,7 +88,7 @@ class AddTransactionViewModel(private val createTransactionUseCase: CreateTransa
                         category = _uiState.value.transactionCategory
                     )
 
-                val result = createTransactionUseCase.execute(transaction).first()
+                val result = createTransactionUseCase(transaction)
 
                 if (result) {
                     // TODO Display successfully created transaction message

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/usecase/CreateTransactionUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/usecase/CreateTransactionUseCaseTest.kt
@@ -1,81 +1,58 @@
 package fr.laforge.benoist.financialmanager.usecase
 
 import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
-import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
 import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
+import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCaseImpl
-import io.mockk.every
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.`should be equal to`
+import org.junit.Before
 import org.junit.Test
-import java.time.LocalDateTime
 
 class CreateTransactionUseCaseTest {
+    private val repository: FinancialRepository = mockk()
+    private lateinit var useCase: CreateTransactionUseCase
 
-    private val repository = mockk<FinancialRepository>()
-    private val useCase = CreateTransactionUseCaseImpl(repository)
-
-    @Test
-    fun `execute should persist only the template when transaction is not periodic`() = runTest {
-        // --- Arrange ---
-        val transaction = Transaction(
-            dateTime = LocalDateTime.now(),
-            type = TransactionType.Expense,
-            amount = 150f,
-            description = "A simple non-periodic transaction"
-        )
-        every { repository.createTransaction(any()) } returns 1
-
-        // --- Act ---
-        val result = useCase.execute(transaction).first()
-
-        // --- Assert ---
-        assertTrue(result)
-        verify(exactly = 1) { repository.createTransaction(transaction) }
-        verify(exactly = 0) { repository.createTransaction(transaction.copy(isPeriodic = false, parent = 1)) }
+    @Before
+    fun setUp() {
+        useCase = CreateTransactionUseCaseImpl(repository)
     }
 
     @Test
-    fun `execute should persist template and child instance when transaction is periodic`() = runTest {
-        // --- Arrange ---
-        val transaction = Transaction(
-            dateTime = LocalDateTime.now(),
-            type = TransactionType.Expense,
-            amount = 150f,
-            description = "A simple periodic transaction",
-            isPeriodic = true
-        )
-        every { repository.createTransaction(any()) } returns 1
+    fun `When transaction is NOT periodic, creates one transaction`() = runBlocking {
+        // Arrange
+        val transaction = Transaction(isPeriodic = false)
+        coEvery { repository.createTransaction(any()) } returns 1L
 
-        // --- Act ---
-        val result = useCase.execute(transaction).first()
+        // Act
+        val result = useCase(transaction)
 
-        // --- Assert ---
-        assertTrue(result)
-        verify(exactly = 1) { repository.createTransaction(transaction) }
-        verify(exactly = 1) { repository.createTransaction(transaction.copy(isPeriodic = false, parent = 1)) }
+        // Assert
+        result `should be equal to` true
+        coVerify(exactly = 1) { repository.createTransaction(transaction) }
     }
 
     @Test
-    fun `invoke should persist only the template when transaction is not periodic`() {
-        // --- Arrange ---
-        val transaction = Transaction(
-            dateTime = LocalDateTime.now(),
-            type = TransactionType.Expense,
-            amount = 50f,
-            description = "One-shot expense"
-        )
-        every { repository.createTransaction(any()) } returns 1
+    fun `When transaction is periodic, creates two transactions`() = runBlocking {
+        // Arrange
+        val transaction = Transaction(uid = 0, isPeriodic = true)
+        val parentId = 1L
+        coEvery { repository.createTransaction(transaction) } returns parentId
+        coEvery { repository.createTransaction(match { it.parent == parentId.toInt() }) } returns 2L
 
-        // --- Act ---
-        val result = useCase.invoke(transaction)
+        // Act
+        val result = useCase(transaction)
 
-        // --- Assert ---
-        assertTrue(result)
-        verify(exactly = 1) { repository.createTransaction(transaction) }
-        verify(exactly = 0) { repository.createTransaction(transaction.copy(isPeriodic = false, parent = 1)) }
+        // Assert
+        result `should be equal to` true
+        coVerify(exactly = 1) { repository.createTransaction(transaction) }
+        coVerify(exactly = 1) {
+            repository.createTransaction(match {
+                it.parent == parentId.toInt() && !it.isPeriodic
+            })
+        }
     }
 }


### PR DESCRIPTION
This PR unifies the CreateTransactionUseCase API by removing duplicate execute() and invoke() methods in favor of a single suspend operator fun invoke(). \n\nChanges include:\n- Updated CreateTransactionUseCase and CreateTransactionUseCaseImpl.\n- Updated AddTransactionViewModel to use the simplified API.\n- Updated CreateTransactionUseCaseTest.