### PR TITLE
[SMELL] Rename misspelled test file (issue #16)

### DIFF
--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetRecurringIncomeUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetRecurringIncomeUseCaseTest.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.junit.Test
 
-class GetReccuringIncomeUseCaseTest {
+class GetRecurringIncomeUseCaseTest {
     // 1. Create the Mock
     private val financialRepository = mockk<FinancialRepository>()
 


### PR DESCRIPTION
This PR fixes a spelling error in the GetRecurringIncomeUseCaseTest file and class names.