### PR TITLE
[ARCH] Remove deprecated getAll() from FinancialRepository (issue #9)

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/repository/FinancialRepository.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/repository/FinancialRepository.kt
@@ -19,12 +19,6 @@ interface FinancialRepository {
     fun getTransactions(filter: TransactionFilter): Flow<List<Transaction>>
 
     /**
-     * Returns all FinancialInput
-     */
-    @Deprecated("Use getTransactions(filter: TransactionFilter) instead")
-    fun getAll(): Flow<List<Transaction>>
-
-    /**
      * Returns all Transaction ins specified date range
      */
     fun getAllInDateRange(startDate: LocalDateTime, endDate: LocalDateTime): Flow<List<Transaction>>

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/AndroidFinancialRepository.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/AndroidFinancialRepository.kt
@@ -30,14 +30,6 @@ class AndroidFinancialRepository(private val financialDao: FinancialInputDao) :
             }
         }
 
-    override fun getAll(): Flow<List<Transaction>> {
-        return financialDao.getAll().map {
-            it.map { input ->
-                input.toModel()
-            }
-        }
-    }
-
     override fun getAllInDateRange(
         startDate: LocalDateTime,
         endDate: LocalDateTime

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/dao/FinancialInputDao.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/dao/FinancialInputDao.kt
@@ -16,9 +16,6 @@ interface FinancialInputDao {
     @Insert
     fun insertAll(financialInputs: List<TransactionEntity>): List<Long>
 
-    @Query("SELECT * FROM transactionentity")
-    fun getAll(): Flow<List<TransactionEntity>>
-
     @Query("SELECT * FROM transactionentity WHERE (date_time >= :startDate AND date_time <= :endDate) AND is_periodic = false ORDER BY date_time DESC")
     fun getAllInDateRange(startDate:LocalDateTime, endDate: LocalDateTime): Flow<List<TransactionEntity>>
 

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/repository/FinancialDaoTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/repository/FinancialDaoTest.kt
@@ -68,7 +68,9 @@ class FinancialDaoTest {
         dao.insertAll(listOf(transaction))
 
         // --- Act ---
-        val transactions = dao.getAll().first()
+        val transactions = dao.getTransactions(
+            null, null, null, null, null, null
+        ).first()
 
         // --- Assert ---
         transactions.size `should be equal to` 1


### PR DESCRIPTION
This PR removes the deprecated getAll() method from FinancialRepository, AndroidFinancialRepository, and FinancialInputDao. It also updates FinancialDaoTest to use the more robust getTransactions() method.