### PR TITLE
[SMELL] Deduplicate Recurring and NonRecurring management ViewModels (issue #11)

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/AbstractTransactionManagementViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/AbstractTransactionManagementViewModel.kt
@@ -1,0 +1,96 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.transaction
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.usecase.DeleteTransactionUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Abstract base [ViewModel] for screens that manage lists of expense and income transactions.
+ *
+ * Provides shared logic for:
+ * 1. Searching/filtering transactions by description.
+ * 2. Calculating monthly totals for both expenses and incomes.
+ * 3. Deleting transactions.
+ *
+ * @param expensesFlow A [Flow] providing the stream of expense transactions.
+ * @param incomesFlow A [Flow] providing the stream of income transactions.
+ * @property deleteTransactionUseCase Use case for transaction deletion.
+ */
+abstract class AbstractTransactionManagementViewModel(
+    expensesFlow: Flow<List<Transaction>>,
+    incomesFlow: Flow<List<Transaction>>,
+    private val deleteTransactionUseCase: DeleteTransactionUseCase
+) : ViewModel() {
+
+    // 1. Raw Data State
+    private val _rawExpenses = expensesFlow.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        emptyList()
+    )
+    private val _rawIncomes = incomesFlow.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        emptyList()
+    )
+
+    // 2. Search State
+    private val _query = MutableStateFlow("")
+    val query: StateFlow<String> = _query.asStateFlow()
+
+    // 3. Filtered Lists (Displayed in UI)
+    val expenseItems: StateFlow<List<Transaction>> = combine(_rawExpenses, _query) { items, query ->
+        if (query.isBlank()) {
+            items
+        } else {
+            items.filter { it.description.contains(query, ignoreCase = true) }
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val incomeItems: StateFlow<List<Transaction>> = combine(_rawIncomes, _query) { items, query ->
+        if (query.isBlank()) {
+            items
+        } else {
+            items.filter { it.description.contains(query, ignoreCase = true) }
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // 4. Total Calculations (Based on filtered lists)
+    val totalExpensesMonthly: StateFlow<Float> = expenseItems.map { list ->
+        list.sumOf { it.amount.toDouble() }.toFloat()
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0f)
+
+    val totalIncomesMonthly: StateFlow<Float> = incomeItems.map { list ->
+        list.sumOf { it.amount.toDouble() }.toFloat()
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0f)
+
+    /**
+     * Updates the current search query.
+     *
+     * @param newQuery The new search string.
+     */
+    fun updateSearch(newQuery: String) {
+        _query.value = newQuery
+    }
+
+    /**
+     * Deletes the specified transaction.
+     *
+     * @param transaction The transaction to delete.
+     */
+    fun deleteTransaction(transaction: Transaction) {
+        viewModelScope.launch {
+            deleteTransactionUseCase(transaction)
+        }
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/non/recurring/NonRecurringExpensesScreen.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/non/recurring/NonRecurringExpensesScreen.kt
@@ -22,7 +22,7 @@ fun NonRecurringExpensesScreen(
     vm: NonRecurringManagementViewModel = koinViewModel(),
 ) {
     // Collect Data
-    val transactions by vm.nonRecurringExpensesItems.collectAsState()
+    val transactions by vm.expenseItems.collectAsState()
     val totalMonthly by vm.totalExpensesMonthly.collectAsState()
     val query by vm.query.collectAsState()
 

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/non/recurring/NonRecurringIncomeScreen.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/non/recurring/NonRecurringIncomeScreen.kt
@@ -22,7 +22,7 @@ fun NonRecurringIncomeScreen(
     vm: NonRecurringManagementViewModel = koinViewModel(),
 ) {
     // Collect Data
-    val transactions by vm.nonRecurringIncomesItems.collectAsState()
+    val transactions by vm.incomeItems.collectAsState()
     val totalMonthly by vm.totalIncomesMonthly.collectAsState()
     val query by vm.query.collectAsState()
 

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/non/recurring/NonRecurringManagementViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/non/recurring/NonRecurringManagementViewModel.kt
@@ -1,76 +1,21 @@
 package fr.laforge.benoist.financialmanager.presentation.ui.transaction.non.recurring
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
 import fr.laforge.benoist.financialmanager.domain.usecase.DeleteTransactionUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetNonRecurringExpenseTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetNonRecurringIncomeTransactionsUseCase
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
+import fr.laforge.benoist.financialmanager.presentation.ui.transaction.AbstractTransactionManagementViewModel
 
+/**
+ * [ViewModel] for the "Non-Recurring Transactions" management screen.
+ *
+ * Manages variable discretionary spending (Expenses) and one-off extra revenue (Incomes).
+ */
 class NonRecurringManagementViewModel(
     getNonRecurringExpenseTransactionsUseCase: GetNonRecurringExpenseTransactionsUseCase,
     getNonRecurringIncomeTransactionsUseCase: GetNonRecurringIncomeTransactionsUseCase,
-    private val deleteTransactionUseCase: DeleteTransactionUseCase,
-) : ViewModel() {
-
-    // 1. Raw Data
-    private val _rawExpenses = getNonRecurringExpenseTransactionsUseCase().stateIn(
-        viewModelScope,
-        SharingStarted.WhileSubscribed(5000),
-        emptyList()
-    )
-    private val _rawIncomes = getNonRecurringIncomeTransactionsUseCase().stateIn(
-        viewModelScope,
-        SharingStarted.WhileSubscribed(5000),
-        emptyList()
-    )
-
-    // 2. Search State
-    private val _query = MutableStateFlow("")
-    val query: StateFlow<String> = _query.asStateFlow()
-
-    // 3. Filtered List (Displayed in UI)
-    val nonRecurringExpensesItems: StateFlow<List<Transaction>> = combine(_rawExpenses, _query) { items, query ->
-        if (query.isBlank()) {
-            items
-        } else {
-            items.filter { it.description.contains(query, ignoreCase = true) }
-        }
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-
-    val nonRecurringIncomesItems: StateFlow<List<Transaction>> = combine(_rawIncomes, _query) { items, query ->
-        if (query.isBlank()) {
-            items
-        } else {
-            items.filter { it.description.contains(query, ignoreCase = true) }
-        }
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-
-    // 4. Total Calculation (Based on filtered list)
-    val totalExpensesMonthly: StateFlow<Float> = nonRecurringExpensesItems.map { list ->
-        list.sumOf { it.amount.toDouble() }.toFloat()
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0f)
-
-    val totalIncomesMonthly: StateFlow<Float> = nonRecurringIncomesItems.map { list ->
-        list.sumOf { it.amount.toDouble() }.toFloat()
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0f)
-
-    fun updateSearch(newQuery: String) {
-        _query.value = newQuery
-    }
-
-    fun deleteTransaction(transaction: Transaction) {
-        viewModelScope.launch {
-            // Logic to delete the template
-            deleteTransactionUseCase(transaction)
-        }
-    }
-}
+    deleteTransactionUseCase: DeleteTransactionUseCase,
+) : AbstractTransactionManagementViewModel(
+    expensesFlow = getNonRecurringExpenseTransactionsUseCase(),
+    incomesFlow = getNonRecurringIncomeTransactionsUseCase(),
+    deleteTransactionUseCase = deleteTransactionUseCase
+)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/recurring/RecurringExpensesScreen.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/recurring/RecurringExpensesScreen.kt
@@ -22,7 +22,7 @@ fun RecurringExpensesScreen(
     vm: RecurringManagementViewModel = koinViewModel(),
 ) {
     // Collect Data
-    val transactions by vm.recurringExpensesItems.collectAsState()
+    val transactions by vm.expenseItems.collectAsState()
     val totalMonthly by vm.totalExpensesMonthly.collectAsState()
     val query by vm.query.collectAsState()
 

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/recurring/RecurringIncomesScreen.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/recurring/RecurringIncomesScreen.kt
@@ -22,7 +22,7 @@ fun RecurringIncomesScreen(
     vm: RecurringManagementViewModel = koinViewModel(),
 ) {
     // Collect Data
-    val transactions by vm.recurringIncomesItems.collectAsState()
+    val transactions by vm.incomeItems.collectAsState()
     val totalMonthly by vm.totalIncomesMonthly.collectAsState()
     val query by vm.query.collectAsState()
 

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/recurring/RecurringManagementViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/recurring/RecurringManagementViewModel.kt
@@ -1,76 +1,21 @@
 package fr.laforge.benoist.financialmanager.presentation.ui.transaction.recurring
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
 import fr.laforge.benoist.financialmanager.domain.usecase.DeleteTransactionUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetRecurringExpenseTemplatesUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetRecurringIncomeTransactionsUseCase
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
+import fr.laforge.benoist.financialmanager.presentation.ui.transaction.AbstractTransactionManagementViewModel
 
+/**
+ * [ViewModel] for the "Recurring Transactions" management screen.
+ *
+ * Manages fixed monthly costs (Expenses) and regular paychecks (Incomes) using templates.
+ */
 class RecurringManagementViewModel(
     getRecurringExpenseTemplatesUseCase: GetRecurringExpenseTemplatesUseCase,
     getRecurringIncomeTransactionsUseCase: GetRecurringIncomeTransactionsUseCase,
-    private val deleteTransactionUseCase: DeleteTransactionUseCase,
-) : ViewModel() {
-
-    // 1. Raw Data
-    private val _rawExpenses = getRecurringExpenseTemplatesUseCase().stateIn(
-            viewModelScope,
-            SharingStarted.WhileSubscribed(5000),
-            emptyList()
-        )
-    private val _rawIncomes = getRecurringIncomeTransactionsUseCase().stateIn(
-        viewModelScope,
-        SharingStarted.WhileSubscribed(5000),
-        emptyList()
-    )
-
-    // 2. Search State
-    private val _query = MutableStateFlow("")
-    val query: StateFlow<String> = _query.asStateFlow()
-
-    // 3. Filtered List (Displayed in UI)
-    val recurringExpensesItems: StateFlow<List<Transaction>> = combine(_rawExpenses, _query) { items, query ->
-        if (query.isBlank()) {
-            items
-        } else {
-            items.filter { it.description.contains(query, ignoreCase = true) }
-        }
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-
-    val recurringIncomesItems: StateFlow<List<Transaction>> = combine(_rawIncomes, _query) { items, query ->
-        if (query.isBlank()) {
-            items
-        } else {
-            items.filter { it.description.contains(query, ignoreCase = true) }
-        }
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-
-    // 4. Total Calculation (Based on filtered list)
-    val totalExpensesMonthly: StateFlow<Float> = recurringExpensesItems.map { list ->
-        list.sumOf { it.amount.toDouble() }.toFloat()
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0f)
-
-    val totalIncomesMonthly: StateFlow<Float> = recurringIncomesItems.map { list ->
-        list.sumOf { it.amount.toDouble() }.toFloat()
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0f)
-
-    fun updateSearch(newQuery: String) {
-        _query.value = newQuery
-    }
-
-    fun deleteTransaction(transaction: Transaction) {
-        viewModelScope.launch {
-            // Logic to delete the template
-            deleteTransactionUseCase(transaction)
-        }
-    }
-}
+    deleteTransactionUseCase: DeleteTransactionUseCase,
+) : AbstractTransactionManagementViewModel(
+    expensesFlow = getRecurringExpenseTemplatesUseCase(),
+    incomesFlow = getRecurringIncomeTransactionsUseCase(),
+    deleteTransactionUseCase = deleteTransactionUseCase
+)


### PR DESCRIPTION
This PR deduplicates logic between RecurringManagementViewModel and NonRecurringManagementViewModel by introducing an AbstractTransactionManagementViewModel base class. \n\nChanges include:\n- Created AbstractTransactionManagementViewModel in presentation.ui.transaction.\n- Refactored RecurringManagementViewModel and NonRecurringManagementViewModel to inherit from the base class.\n- Updated relevant UI screens to use the new property names from the base class.