### PR TITLE
[ENHANCEMENT] Create GetTransactionByIdUseCase — remove direct repo calls from ViewModels (issue #6)

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/useCaseModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/useCaseModule.kt
@@ -28,6 +28,7 @@ import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetAllTran
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetMonthlyTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetNonRecurringExpenseTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetNonRecurringIncomeTransactionsUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetTransactionByIdUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetRecurringExpenseTemplatesUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetRecurringIncomeTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.util.Logger
@@ -43,6 +44,7 @@ val useCaseModule by lazy {
 
         factoryOf(::ExportTransactionsListUseCase)
         factoryOf(::GetAllTransactionsUseCase)
+        factoryOf(::GetTransactionByIdUseCase)
         factoryOf(::GetAllRecurringTransactionsUseCase)
         factory<CreateTransactionUseCase> { CreateTransactionUseCaseImpl(repository = get()) }
         factory<CreateRegularTransactionsUseCase> {

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/viewModelModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/viewModelModule.kt
@@ -12,6 +12,7 @@ import fr.laforge.benoist.financialmanager.presentation.ui.transaction.detail.Tr
 import fr.laforge.benoist.financialmanager.presentation.ui.transaction.non.recurring.NonRecurringManagementViewModel
 import fr.laforge.benoist.financialmanager.presentation.ui.transaction.recurring.RecurringManagementViewModel
 import fr.laforge.benoist.financialmanager.presentation.ui.transaction.update.UpdateTransactionViewModel
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetTransactionByIdUseCase
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
@@ -41,14 +42,14 @@ val viewModelModule by lazy {
         viewModel {
             TransactionDetailsViewModel(
                 savedStateHandle = get(),
-                financialRepository = get(),
+                getTransactionByIdUseCase = get(),
             )
         }
 
         viewModel {
             UpdateTransactionViewModel(
                 savedStateHandle = get(),
-                financialRepository = get(),
+                getTransactionByIdUseCase = get(),
                 transactionInteractor = get(),
             )
         }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetTransactionByIdUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetTransactionByIdUseCase.kt
@@ -1,0 +1,33 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.transaction
+
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Use case responsible for retrieving a single [Transaction] by its unique identifier.
+ *
+ * Centralising this lookup in a use case ensures that ViewModels and other callers
+ * never hold a direct reference to [FinancialRepository], preserving the Clean
+ * Architecture dependency rule (presentation → domain, never → data).
+ *
+ * @property repository The [FinancialRepository] that is the source of truth for transactions.
+ */
+class GetTransactionByIdUseCase(private val repository: FinancialRepository) {
+
+    /**
+     * Returns a [Flow] that emits the [Transaction] matching [id].
+     *
+     * The flow is backed by the repository's reactive stream, so any downstream
+     * update to that row will automatically re-emit to collectors.
+     *
+     * @param id The unique identifier of the transaction to retrieve.
+     * @return A [Flow] emitting the matching [Transaction].
+     *
+     * @note The repository contract returns a hot-ish Flow (Room LiveData-backed).
+     * Callers are expected to apply [kotlinx.coroutines.flow.filterNotNull] if the
+     * row may be absent, rather than performing null-safety checks here — keeping
+     * this use case a pure delegation without defensive logic for absent records.
+     */
+    operator fun invoke(id: Int): Flow<Transaction> = repository.get(uid = id)
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/detail/TransactionDetailsViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/detail/TransactionDetailsViewModel.kt
@@ -3,29 +3,38 @@ package fr.laforge.benoist.financialmanager.presentation.ui.transaction.detail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetTransactionByIdUseCase
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import org.koin.core.component.KoinComponent
-import timber.log.Timber
 
+/**
+ * ViewModel for the transaction detail screen.
+ *
+ * Loads a single transaction by its ID (taken from [SavedStateHandle]) and exposes
+ * it as a [StateFlow] of [TransactionUiState] for the UI to observe.
+ *
+ * @property savedStateHandle Provides the [transactionId] navigation argument.
+ * @property getTransactionByIdUseCase Domain use case that fetches the transaction reactively.
+ *
+ * @note [FinancialRepository] is intentionally absent from this constructor. All data
+ * access must go through the use case layer to honour the Clean Architecture dependency rule.
+ */
 class TransactionDetailsViewModel(
     savedStateHandle: SavedStateHandle,
-    financialRepository: FinancialRepository
+    private val getTransactionByIdUseCase: GetTransactionByIdUseCase,
 ) : ViewModel() {
+
     private val transactionId = savedStateHandle.get<Int>("transactionId") ?: 0
 
-    val uiState: StateFlow<TransactionUiState> = financialRepository.get(uid = transactionId)
+    val uiState: StateFlow<TransactionUiState> = getTransactionByIdUseCase(transactionId)
         .filterNotNull()
-        .map {
-            TransactionUiState(transaction = it)
-        }
+        .map { TransactionUiState(transaction = it) }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
+            started = SharingStarted.WhileSubscribed(5_000),
             initialValue = TransactionUiState()
         )
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/update/UpdateTransactionViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/update/UpdateTransactionViewModel.kt
@@ -7,11 +7,11 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import fr.laforge.benoist.financialmanager.domain.usecase.TransactionInteractor
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetTransactionByIdUseCase
 import fr.laforge.benoist.financialmanager.presentation.ui.transaction.detail.TransactionUiState
 import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
 import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionCategory
 import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
-import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,11 +22,28 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+/**
+ * ViewModel for the update-transaction screen.
+ *
+ * Loads the target transaction on initialisation, exposes editable state to the UI,
+ * and delegates all mutations to [TransactionInteractor] so that business rules
+ * (e.g. cascading parent updates) are enforced in the domain layer.
+ *
+ * @property savedStateHandle Provides the [transactionId] navigation argument.
+ * @property getTransactionByIdUseCase Domain use case for the initial data load.
+ * @property transactionInteractor Orchestrates update and periodic-check operations.
+ *
+ * @note [FinancialRepository] is intentionally absent from this constructor. The second
+ * [updateTransaction] overload previously called the repository directly; it now routes
+ * through [TransactionInteractor] with [shouldUpdateParent] = false, keeping the
+ * presentation layer free of data-layer dependencies.
+ */
 class UpdateTransactionViewModel(
     savedStateHandle: SavedStateHandle,
-    private val financialRepository: FinancialRepository,
+    private val getTransactionByIdUseCase: GetTransactionByIdUseCase,
     private val transactionInteractor: TransactionInteractor,
 ) : ViewModel() {
+
     private val transactionId = savedStateHandle["transactionId"] ?: 0
     var uiState: TransactionUiState by mutableStateOf(TransactionUiState())
     private val _updateTransactionResult = MutableStateFlow<Result<Boolean>>(Result.success(false))
@@ -35,21 +52,27 @@ class UpdateTransactionViewModel(
     init {
         viewModelScope.launch {
             uiState = TransactionUiState(
-                financialRepository.get(uid = transactionId)
+                getTransactionByIdUseCase(transactionId)
                     .filterNotNull()
                     .first()
             )
         }
     }
 
+    /**
+     * Returns whether [transaction] is a periodic (recurring) transaction.
+     *
+     * @param transaction The transaction to inspect.
+     * @return `true` if the transaction is periodic, `false` otherwise.
+     */
     fun isPeriodicTransaction(transaction: Transaction) =
         transactionInteractor.isPeriodicTransaction(transaction)
 
     /**
-     * Updates a transaction.
+     * Updates [transaction] via the interactor, optionally cascading to its parent.
      *
-     * @param transaction The transaction to update.
-     * @param shouldUpdateParent Whether to update the parent transaction if it exists.
+     * @param transaction The transaction to persist.
+     * @param shouldUpdateParent Whether to propagate changes to the parent recurring template.
      */
     fun updateTransaction(
         transaction: Transaction,
@@ -65,15 +88,42 @@ class UpdateTransactionViewModel(
         }
     }
 
+    /**
+     * Persists the current [uiState] transaction without cascading to the parent.
+     *
+     * @param dispatcher Coroutine dispatcher to use for the IO operation (injectable for testing).
+     */
+    fun updateTransaction(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+        viewModelScope.launch(dispatcher) {
+            transactionInteractor.updateTransaction(uiState.transaction, shouldUpdateParent = false)
+        }
+    }
+
+    /**
+     * Updates the transaction type in the local UI state.
+     *
+     * @param transactionType The new [TransactionType] to apply.
+     */
     fun updateInputType(transactionType: TransactionType) {
         uiState = uiState.copy(transaction = uiState.transaction.copy(type = transactionType))
     }
 
+    /**
+     * Updates the transaction category in the local UI state.
+     *
+     * @param transactionCategory The new [TransactionCategory] to apply.
+     */
     fun updateTransactionCategory(transactionCategory: TransactionCategory) {
         uiState =
             uiState.copy(transaction = uiState.transaction.copy(category = transactionCategory))
     }
 
+    /**
+     * Parses [amount] and updates the amount in the local UI state.
+     * Logs a warning and discards the value if [amount] is not a valid number.
+     *
+     * @param amount Raw string amount from the UI input field.
+     */
     fun updateAmount(amount: String) {
         try {
             uiState =
@@ -83,16 +133,12 @@ class UpdateTransactionViewModel(
         }
     }
 
+    /**
+     * Updates the description in the local UI state.
+     *
+     * @param newDescription The new description string.
+     */
     fun updateDescription(newDescription: String) {
         uiState = uiState.copy(transaction = uiState.transaction.copy(description = newDescription))
-    }
-
-    /**
-     * Updates the transaction
-     */
-    fun updateTransaction(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-        viewModelScope.launch(dispatcher) {
-            financialRepository.updateTransaction(uiState.transaction)
-        }
     }
 }

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetTransactionByIdUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetTransactionByIdUseCaseTest.kt
@@ -1,0 +1,69 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.transaction
+
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
+import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class GetTransactionByIdUseCaseTest {
+
+    private val repository = mockk<FinancialRepository>()
+    private val useCase = GetTransactionByIdUseCase(repository)
+
+    // --- Happy Path ---
+
+    @Test
+    fun `invoke should return the transaction matching the given id`() = runTest {
+        // --- Arrange ---
+        val expected = Transaction(
+            uid = 42,
+            description = "Grocery shopping",
+            amount = 75f,
+            type = TransactionType.Expense,
+            isPeriodic = false
+        )
+        every { repository.get(uid = 42) } returns flowOf(expected)
+
+        // --- Act ---
+        val result = useCase(42).first()
+
+        // --- Assert ---
+        result shouldBeEqualTo expected
+    }
+
+    // --- Edge Cases ---
+
+    @Test
+    fun `invoke should delegate to repository with the exact id provided`() = runTest {
+        // --- Arrange ---
+        val transaction = Transaction(uid = 7, description = "Bus pass", amount = 30f)
+        every { repository.get(uid = 7) } returns flowOf(transaction)
+
+        // --- Act ---
+        useCase(7).first()
+
+        // --- Assert ---
+        verify(exactly = 1) { repository.get(uid = 7) }
+    }
+
+    @Test
+    fun `invoke with id zero should still delegate to repository without short-circuiting`() = runTest {
+        // --- Arrange ---
+        val transaction = Transaction(uid = 0, description = "Placeholder", amount = 0f)
+        every { repository.get(uid = 0) } returns flowOf(transaction)
+
+        // --- Act ---
+        val result = useCase(0).first()
+
+        // --- Assert ---
+        result shouldBeEqualTo transaction
+        verify(exactly = 1) { repository.get(uid = 0) }
+    }
+}


### PR DESCRIPTION
## Summary

- Create `GetTransactionByIdUseCase` in `domain/usecase/transaction/` wrapping `FinancialRepository.get(uid)`
- Refactor `TransactionDetailsViewModel` and `UpdateTransactionViewModel` to depend on the new use case instead of `FinancialRepository` directly
- Route the bare `updateTransaction()` call in `UpdateTransactionViewModel` through `TransactionInteractor` (was calling `financialRepository.updateTransaction()` directly)
- Register `GetTransactionByIdUseCase` in `useCaseModule` via `factoryOf`
- Update `viewModelModule` to inject the use case into both ViewModels

Closes #6

## Test plan

- [x] `GetTransactionByIdUseCaseTest` — happy path: correct transaction returned by id
- [x] `GetTransactionByIdUseCaseTest` — edge case: delegation verified (repository called with exact id)
- [x] `GetTransactionByIdUseCaseTest` — edge case: zero id is forwarded without short-circuiting
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)