### PR TITLE
[ENHANCEMENT] Create ImportTransactionsUseCase — move CSV parsing out of ImportDbViewModel (issue #7)

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/useCaseModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/useCaseModule.kt
@@ -29,6 +29,7 @@ import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetMonthly
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetNonRecurringExpenseTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetNonRecurringIncomeTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetTransactionByIdUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.ImportTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetRecurringExpenseTemplatesUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetRecurringIncomeTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.util.Logger
@@ -45,6 +46,7 @@ val useCaseModule by lazy {
         factoryOf(::ExportTransactionsListUseCase)
         factoryOf(::GetAllTransactionsUseCase)
         factoryOf(::GetTransactionByIdUseCase)
+        factoryOf(::ImportTransactionsUseCase)
         factoryOf(::GetAllRecurringTransactionsUseCase)
         factory<CreateTransactionUseCase> { CreateTransactionUseCaseImpl(repository = get()) }
         factory<CreateRegularTransactionsUseCase> {

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/viewModelModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/viewModelModule.kt
@@ -13,6 +13,7 @@ import fr.laforge.benoist.financialmanager.presentation.ui.transaction.non.recur
 import fr.laforge.benoist.financialmanager.presentation.ui.transaction.recurring.RecurringManagementViewModel
 import fr.laforge.benoist.financialmanager.presentation.ui.transaction.update.UpdateTransactionViewModel
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetTransactionByIdUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.ImportTransactionsUseCase
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
@@ -32,7 +33,7 @@ val viewModelModule by lazy {
         viewModelOf(::HomeScreenViewModel)
 
         viewModel {
-            ImportDbViewModel(repository = get())
+            ImportDbViewModel(importTransactionsUseCase = get())
         }
 
         viewModel {

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/ImportTransactionsUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/ImportTransactionsUseCase.kt
@@ -23,6 +23,11 @@ class ImportTransactionsUseCase(
     private val createTransactionUseCase: CreateTransactionUseCase,
 ) {
 
+    companion object {
+        /** Delimiter separating individual transaction records within a CSV payload. */
+        private const val LINE_SEPARATOR = '\n'
+    }
+
     /**
      * Parses [csv] line-by-line and persists each valid transaction.
      *
@@ -35,7 +40,7 @@ class ImportTransactionsUseCase(
      */
     suspend operator fun invoke(csv: String): Int {
         var imported = 0
-        csv.split('\n').forEach { line ->
+        csv.split(LINE_SEPARATOR).forEach { line ->
             try {
                 val transaction = transactionFromCsv(line)
                 createTransactionUseCase(transaction)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/ImportTransactionsUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/ImportTransactionsUseCase.kt
@@ -23,11 +23,6 @@ class ImportTransactionsUseCase(
     private val createTransactionUseCase: CreateTransactionUseCase,
 ) {
 
-    companion object {
-        /** Delimiter separating individual transaction records within a CSV payload. */
-        private const val LINE_SEPARATOR = '\n'
-    }
-
     /**
      * Parses [csv] line-by-line and persists each valid transaction.
      *
@@ -50,5 +45,10 @@ class ImportTransactionsUseCase(
             }
         }
         return imported
+    }
+
+    companion object {
+        /** Delimiter separating individual transaction records within a CSV payload. */
+        private const val LINE_SEPARATOR = '\n'
     }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/ImportTransactionsUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/ImportTransactionsUseCase.kt
@@ -1,0 +1,49 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.transaction
+
+import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
+import fr.laforge.benoist.financialmanager.domain.util.transactionFromCsv
+import timber.log.Timber
+
+/**
+ * Use case responsible for importing a batch of transactions from a raw CSV string.
+ *
+ * Centralising this logic in the domain layer ensures that the ViewModel remains a
+ * thin coordinator of UI state, free from parsing concerns and direct repository access.
+ *
+ * The CSV format expected per line is defined by [fr.laforge.benoist.financialmanager.domain.util.exportToCsvFormat]:
+ * `uid;dateTimeMillis;amount;description;type;isPeriodic;period;parent;category`
+ *
+ * @property createTransactionUseCase Domain use case that persists a single transaction.
+ *
+ * @note Lines that cannot be parsed are silently skipped — this mirrors the original
+ * ViewModel behaviour and is intentional: a partial import is better than a full failure
+ * when dealing with user-supplied CSV data that may contain blank lines or encoding artefacts.
+ */
+class ImportTransactionsUseCase(
+    private val createTransactionUseCase: CreateTransactionUseCase,
+) {
+
+    /**
+     * Parses [csv] line-by-line and persists each valid transaction.
+     *
+     * @param csv Raw CSV string where each line represents one transaction.
+     * @return The number of transactions successfully imported.
+     *
+     * @note Malformed lines are caught and logged at warning level, then skipped.
+     * The caller receives the count of successfully persisted rows so it can surface
+     * a meaningful result to the user if needed.
+     */
+    suspend operator fun invoke(csv: String): Int {
+        var imported = 0
+        csv.split('\n').forEach { line ->
+            try {
+                val transaction = transactionFromCsv(line)
+                createTransactionUseCase(transaction)
+                imported++
+            } catch (e: Exception) {
+                Timber.w(e, "Skipping malformed CSV line: $line")
+            }
+        }
+        return imported
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/db/ImportDbViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/db/ImportDbViewModel.kt
@@ -5,38 +5,51 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
-import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
-import fr.laforge.benoist.financialmanager.domain.util.transactionFromCsv
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.ImportTransactionsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-class ImportDbViewModel(private val repository: FinancialRepository) : ViewModel() {
+/**
+ * ViewModel for the database-import screen.
+ *
+ * Holds the raw CSV text entered by the user and delegates all parsing and
+ * persistence work to [ImportTransactionsUseCase], keeping this class free of
+ * domain or data-layer logic.
+ *
+ * @property importTransactionsUseCase Domain use case that parses CSV and persists transactions.
+ *
+ * @note [FinancialRepository] is intentionally absent — data access is fully encapsulated
+ * in the use case layer to honour the Clean Architecture dependency rule.
+ */
+class ImportDbViewModel(
+    private val importTransactionsUseCase: ImportTransactionsUseCase,
+) : ViewModel() {
+
     var toBeImported by mutableStateOf("")
         private set
 
+    /**
+     * Updates the raw CSV text that will be imported.
+     *
+     * @param newValue The new CSV string from the UI input field.
+     */
     fun updateToBeImported(newValue: String) {
         toBeImported = newValue
         Timber.d(newValue)
     }
 
+    /**
+     * Triggers the import of all transactions encoded in [toBeImported].
+     *
+     * Delegates entirely to [ImportTransactionsUseCase]; malformed lines are
+     * silently skipped by the use case.
+     */
     fun importDb() {
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
-                val transactionsList = mutableListOf<Transaction>()
-                toBeImported.split('\n').forEach {
-                    try{
-                        transactionsList.add(transactionFromCsv(it))
-                    } catch (e: Exception) {
-                        // Do Nothing
-                    }
-                }
-
-                transactionsList.forEach {
-                    repository.createTransaction(it)
-                }
+                importTransactionsUseCase(toBeImported)
             }
         }
     }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/db/ImportDbViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/db/ImportDbViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.ImportTransactionsUseCase
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -19,12 +20,15 @@ import timber.log.Timber
  * domain or data-layer logic.
  *
  * @property importTransactionsUseCase Domain use case that parses CSV and persists transactions.
+ * @property dispatcher Coroutine dispatcher used for IO work; defaults to [Dispatchers.IO].
+ *   Override in tests to keep execution synchronous.
  *
  * @note [FinancialRepository] is intentionally absent — data access is fully encapsulated
  * in the use case layer to honour the Clean Architecture dependency rule.
  */
 class ImportDbViewModel(
     private val importTransactionsUseCase: ImportTransactionsUseCase,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
     var toBeImported by mutableStateOf("")
@@ -48,7 +52,7 @@ class ImportDbViewModel(
      */
     fun importDb() {
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
+            withContext(dispatcher) {
                 importTransactionsUseCase(toBeImported)
             }
         }

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/ImportTransactionsUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/ImportTransactionsUseCaseTest.kt
@@ -1,0 +1,70 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.transaction
+
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionCategory
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionPeriod
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
+import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class ImportTransactionsUseCaseTest {
+
+    private val createTransactionUseCase = mockk<CreateTransactionUseCase>()
+    private val useCase = ImportTransactionsUseCase(createTransactionUseCase)
+
+    // A valid CSV line produced by Transaction.exportToCsvFormat():
+    // uid;dateTimeMillis;amount;description;type;isPeriodic;period;parent;category
+    private val validLine1 = "1;1700000000000;50.0;Groceries;Expense;false;None;0;Food"
+    private val validLine2 = "2;1700100000000;3000.0;Salary;Income;false;None;0;None"
+
+    // --- Happy Path ---
+
+    @Test
+    fun `invoke should parse and persist all valid CSV lines`() = runTest {
+        // --- Arrange ---
+        coEvery { createTransactionUseCase(any()) } returns true
+        val csv = "$validLine1\n$validLine2"
+
+        // --- Act ---
+        val result = useCase(csv)
+
+        // --- Assert ---
+        result shouldBeEqualTo 2
+        coVerify(exactly = 2) { createTransactionUseCase(any()) }
+    }
+
+    // --- Edge Cases ---
+
+    @Test
+    fun `invoke should skip malformed lines and still import valid ones`() = runTest {
+        // --- Arrange ---
+        coEvery { createTransactionUseCase(any()) } returns true
+        val csv = "$validLine1\nTHIS_IS_NOT_VALID\n$validLine2"
+
+        // --- Act ---
+        val result = useCase(csv)
+
+        // --- Assert ---
+        result shouldBeEqualTo 2
+        coVerify(exactly = 2) { createTransactionUseCase(any()) }
+    }
+
+    @Test
+    fun `invoke with empty string should not call createTransactionUseCase`() = runTest {
+        // --- Arrange ---
+        // An empty string split by '\n' yields one element: [""].
+        // transactionFromCsv("") will throw, so no transactions should be persisted.
+
+        // --- Act ---
+        val result = useCase("")
+
+        // --- Assert ---
+        result shouldBeEqualTo 0
+        coVerify(exactly = 0) { createTransactionUseCase(any()) }
+    }
+}


### PR DESCRIPTION
## Summary

- Create `ImportTransactionsUseCase` in `domain/usecase/transaction/` that owns CSV line splitting, parsing via `transactionFromCsv()`, and delegation to `CreateTransactionUseCase`; malformed lines are silently skipped (preserving original behaviour)
- Refactor `ImportDbViewModel`: remove `FinancialRepository`, inject `ImportTransactionsUseCase`; `importDb()` becomes a single use case call
- Register `ImportTransactionsUseCase` in `useCaseModule` via `factoryOf`
- Update `viewModelModule` to inject the new use case into `ImportDbViewModel`

Closes #7

## Test plan

- [x] `ImportTransactionsUseCaseTest` — happy path: all valid lines parsed and persisted
- [x] `ImportTransactionsUseCaseTest` — edge case: malformed lines skipped, valid ones still imported
- [x] `ImportTransactionsUseCaseTest` — edge case: empty string produces zero calls to `CreateTransactionUseCase`
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)