### PR TITLE
[ENHANCEMENT] Abstract biometric authentication — remove AndroidX imports from LoginViewModel (issue #8)

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/helperModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/helperModule.kt
@@ -1,14 +1,24 @@
 package fr.laforge.benoist.financialmanager.di.module
 
+import androidx.fragment.app.FragmentActivity
+import fr.laforge.benoist.financialmanager.domain.usecase.BiometricAuthenticator
 import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationHelper
+import fr.laforge.benoist.financialmanager.infrastructure.auth.BiometricAuthenticatorImpl
 import fr.laforge.benoist.financialmanager.infrastructure.helper.NotificationHelperImpl
 import fr.laforge.benoist.financialmanager.infrastructure.service.AndroidExportService
 import fr.laforge.benoist.financialmanager.infrastructure.service.NotificationListenerHelper
 import fr.laforge.benoist.financialmanager.presentation.util.ExportService
+import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 
 val helperModule by lazy {
     module {
+        // BiometricPrompt requires a live FragmentActivity — must be a factory (never singleton)
+        // so each activity instance receives its own authenticator with a fresh reference.
+        factory<BiometricAuthenticator> { (activity: FragmentActivity) ->
+            BiometricAuthenticatorImpl(activity = activity)
+        }
+
         single<ExportService> {
             AndroidExportService(context = get())
         }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/viewModelModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/viewModelModule.kt
@@ -12,10 +12,12 @@ import fr.laforge.benoist.financialmanager.presentation.ui.transaction.detail.Tr
 import fr.laforge.benoist.financialmanager.presentation.ui.transaction.non.recurring.NonRecurringManagementViewModel
 import fr.laforge.benoist.financialmanager.presentation.ui.transaction.recurring.RecurringManagementViewModel
 import fr.laforge.benoist.financialmanager.presentation.ui.transaction.update.UpdateTransactionViewModel
+import androidx.fragment.app.FragmentActivity
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetTransactionByIdUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.ImportTransactionsUseCase
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 
 val viewModelModule by lazy {
@@ -36,8 +38,10 @@ val viewModelModule by lazy {
             ImportDbViewModel(importTransactionsUseCase = get())
         }
 
-        viewModel {
-            LoginViewModel()
+        viewModel { (activity: FragmentActivity) ->
+            LoginViewModel(
+                biometricAuthenticator = get { parametersOf(activity) },
+            )
         }
 
         viewModel {

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/BiometricAuthenticator.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/BiometricAuthenticator.kt
@@ -1,0 +1,36 @@
+package fr.laforge.benoist.financialmanager.domain.usecase
+
+/**
+ * Port for triggering a biometric authentication challenge.
+ *
+ * Defining this boundary in the domain layer keeps ViewModels and business logic
+ * free of any Android biometric framework dependency, making them fully unit-testable
+ * without an Android runtime.
+ *
+ * The concrete implementation lives in the infrastructure layer and is injected at
+ * runtime via the DI container.
+ */
+interface BiometricAuthenticator {
+
+    /**
+     * Presents a biometric prompt to the user and reports the outcome via callbacks.
+     *
+     * @param title             Primary text shown at the top of the prompt dialog.
+     * @param subTitle          Secondary text shown below the title.
+     * @param description       Longer explanation displayed in the prompt body.
+     * @param negativeButtonText Label for the cancel / fallback button.
+     * @param onAuthenticationOk    Invoked when the user is successfully authenticated.
+     * @param onAuthenticationFailed Invoked when authentication is denied or encounters an error.
+     *
+     * @note Both callbacks are guaranteed to be called on the thread that the underlying
+     * platform executor dispatches to. Callers should not assume a particular thread.
+     */
+    fun authenticate(
+        title: String,
+        subTitle: String,
+        description: String,
+        negativeButtonText: String,
+        onAuthenticationOk: () -> Unit,
+        onAuthenticationFailed: () -> Unit,
+    )
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/auth/BiometricAuthenticatorImpl.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/auth/BiometricAuthenticatorImpl.kt
@@ -1,0 +1,85 @@
+package fr.laforge.benoist.financialmanager.infrastructure.auth
+
+import android.os.Looper
+import androidx.biometric.BiometricPrompt
+import androidx.fragment.app.FragmentActivity
+import fr.laforge.benoist.financialmanager.domain.usecase.BiometricAuthenticator
+import timber.log.Timber
+
+/**
+ * Android implementation of [BiometricAuthenticator] backed by [BiometricPrompt].
+ *
+ * Lives in the infrastructure layer so that all Android biometric framework imports
+ * are isolated here, away from the domain and presentation layers.
+ *
+ * @property activity The [FragmentActivity] required by [BiometricPrompt] to attach
+ *   the authentication dialog. Provided via Koin parametric injection from the
+ *   composable that owns the current activity context.
+ *
+ * @note [BiometricPrompt] requires a live [FragmentActivity]; this class must therefore
+ * be registered as a Koin `factory` (not a `single`) so a fresh instance is created
+ * for each activity lifecycle. Registering as a singleton would risk holding a stale
+ * activity reference after recreation.
+ */
+class BiometricAuthenticatorImpl(
+    private val activity: FragmentActivity,
+) : BiometricAuthenticator {
+
+    /**
+     * Builds and displays a [BiometricPrompt] dialog.
+     *
+     * @param title             Primary heading shown in the system dialog.
+     * @param subTitle          Sub-heading shown below the title.
+     * @param description       Body text of the dialog.
+     * @param negativeButtonText Label for the negative/cancel button.
+     * @param onAuthenticationOk    Called on successful biometric verification.
+     * @param onAuthenticationFailed Called on any authentication failure or error.
+     *
+     * @note A [Looper] is prepared for the executor thread if not already present,
+     * matching the original workaround required by certain device implementations.
+     */
+    override fun authenticate(
+        title: String,
+        subTitle: String,
+        description: String,
+        negativeButtonText: String,
+        onAuthenticationOk: () -> Unit,
+        onAuthenticationFailed: () -> Unit,
+    ) {
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(title)
+            .setSubtitle(subTitle)
+            .setDescription(description)
+            .setNegativeButtonText(negativeButtonText)
+            .build()
+
+        val biometricPrompt = BiometricPrompt(
+            activity,
+            { runnable ->
+                if (Looper.myLooper() == null) Looper.prepare()
+                runnable.run()
+            },
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                    super.onAuthenticationError(errorCode, errString)
+                    Timber.e("Biometric authentication error $errorCode — $errString")
+                    onAuthenticationFailed()
+                }
+
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    super.onAuthenticationSucceeded(result)
+                    Timber.d("Biometric authentication succeeded")
+                    onAuthenticationOk()
+                }
+
+                override fun onAuthenticationFailed() {
+                    super.onAuthenticationFailed()
+                    Timber.e("Biometric authentication failed")
+                    onAuthenticationFailed()
+                }
+            }
+        )
+
+        biometricPrompt.authenticate(promptInfo)
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/login/LoginScreen.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/login/LoginScreen.kt
@@ -33,13 +33,15 @@ import androidx.navigation.compose.rememberNavController
 import fr.laforge.benoist.financialmanager.R
 import fr.laforge.benoist.financialmanager.presentation.ui.FinancialManagerScreen
 import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 
 @Composable
 fun LoginScreen(
     navController: NavController,
     modifier: Modifier = Modifier,
-    vm: LoginViewModel = koinViewModel(),
 ) {
+    val activity = LocalContext.current as FragmentActivity
+    val vm: LoginViewModel = koinViewModel(parameters = { parametersOf(activity) })
     var displayBiometrics by remember {
         mutableStateOf(true)
     }
@@ -95,18 +97,17 @@ fun LoginScreen(
     }
 
     if (displayBiometrics) {
-        vm.displayBiometricAuthenticator(
-            activity = LocalContext.current as FragmentActivity,
+        vm.authenticate(
             title = stringResource(id = R.string.biometric_title),
             subTitle = "",
             description = stringResource(id = R.string.biometric_subtitle),
             negativeButtonText = stringResource(id = R.string.biometric_negative),
-            {
+            onAuthenticationOk = {
                 displayBiometrics = false
                 // Navigate to next screen
                 navController.navigate(route = FinancialManagerScreen.Home.name)
             },
-            {
+            onAuthenticationFailed = {
                 displayBiometrics = false
                 // Display error
             }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/login/LoginViewModel.kt
@@ -1,56 +1,50 @@
 package fr.laforge.benoist.financialmanager.presentation.ui.login
 
-import android.os.Looper
-import androidx.biometric.BiometricPrompt
-import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
-import timber.log.Timber
+import fr.laforge.benoist.financialmanager.domain.usecase.BiometricAuthenticator
 
-class LoginViewModel : ViewModel() {
+/**
+ * ViewModel for the login screen.
+ *
+ * Delegates all biometric authentication to [BiometricAuthenticator], keeping this
+ * class free of any Android biometric framework dependency and making it fully
+ * unit-testable without an Android runtime.
+ *
+ * @property biometricAuthenticator Domain port that abstracts the biometric prompt.
+ *
+ * @note No Android framework types (`BiometricPrompt`, `FragmentActivity`, etc.) are
+ * imported here by design — this enforces the Zero Framework Policy in the presentation
+ * layer and ensures the ViewModel remains independently testable.
+ */
+class LoginViewModel(
+    private val biometricAuthenticator: BiometricAuthenticator,
+) : ViewModel() {
+
     /**
-     * Displays a biometric authentication dialog
+     * Triggers a biometric authentication challenge.
+     *
+     * @param title              Primary heading shown in the system dialog.
+     * @param subTitle           Sub-heading shown below the title.
+     * @param description        Body text of the dialog.
+     * @param negativeButtonText Label for the negative/cancel button.
+     * @param onAuthenticationOk     Invoked when the user authenticates successfully.
+     * @param onAuthenticationFailed Invoked when authentication is denied or errors.
      */
-    fun displayBiometricAuthenticator(
-        activity: FragmentActivity,
+    fun authenticate(
         title: String,
         subTitle: String,
         description: String,
         negativeButtonText: String,
         onAuthenticationOk: () -> Unit,
-        onAuthenticationFailed: () -> Unit
+        onAuthenticationFailed: () -> Unit,
     ) {
-        val promptInfo = BiometricPrompt.PromptInfo.Builder()
-            .setTitle(title)
-            .setSubtitle(subTitle)
-            .setDescription(description)
-            .setNegativeButtonText(negativeButtonText)
-            .build()
-        val biometricPrompt = BiometricPrompt(activity, {
-            if (Looper.myLooper() == null) {
-                Looper.prepare()
-            }
-            it.run()
-        }, object : BiometricPrompt.AuthenticationCallback() {
-            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
-                super.onAuthenticationError(errorCode, errString)
-                Timber.e("Attempt to authenticate the user has failed $errorCode - $errString")
-                onAuthenticationFailed()
-            }
-
-            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-                super.onAuthenticationSucceeded(result)
-                Timber.d("User authentication succeeded")
-                onAuthenticationOk()
-            }
-
-            override fun onAuthenticationFailed() {
-                super.onAuthenticationFailed()
-                Timber.e("Attempt to authenticate the user has failed")
-                onAuthenticationFailed()
-            }
-        }
+        biometricAuthenticator.authenticate(
+            title = title,
+            subTitle = subTitle,
+            description = description,
+            negativeButtonText = negativeButtonText,
+            onAuthenticationOk = onAuthenticationOk,
+            onAuthenticationFailed = onAuthenticationFailed,
         )
-
-        biometricPrompt.authenticate(promptInfo)
     }
 }

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/login/LoginViewModelTest.kt
@@ -1,0 +1,99 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.login
+
+import fr.laforge.benoist.financialmanager.domain.usecase.BiometricAuthenticator
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class LoginViewModelTest {
+
+    private val biometricAuthenticator = mockk<BiometricAuthenticator>(relaxed = true)
+    private val viewModel = LoginViewModel(biometricAuthenticator)
+
+    // --- Happy Path ---
+
+    @Test
+    fun `authenticate should delegate all parameters to BiometricAuthenticator`() {
+        // --- Arrange ---
+        val onOk = mockk<() -> Unit>(relaxed = true)
+        val onFailed = mockk<() -> Unit>(relaxed = true)
+
+        // --- Act ---
+        viewModel.authenticate(
+            title = "Login",
+            subTitle = "Subtitle",
+            description = "Please authenticate",
+            negativeButtonText = "Cancel",
+            onAuthenticationOk = onOk,
+            onAuthenticationFailed = onFailed,
+        )
+
+        // --- Assert ---
+        verify(exactly = 1) {
+            biometricAuthenticator.authenticate(
+                title = "Login",
+                subTitle = "Subtitle",
+                description = "Please authenticate",
+                negativeButtonText = "Cancel",
+                onAuthenticationOk = onOk,
+                onAuthenticationFailed = onFailed,
+            )
+        }
+    }
+
+    // --- Edge Cases ---
+
+    @Test
+    fun `authenticate should invoke onAuthenticationOk callback when authenticator succeeds`() {
+        // --- Arrange ---
+        var okCalled = false
+        val onOkSlot = slot<() -> Unit>()
+
+        io.mockk.every {
+            biometricAuthenticator.authenticate(any(), any(), any(), any(), capture(onOkSlot), any())
+        } answers {
+            onOkSlot.captured.invoke()
+        }
+
+        // --- Act ---
+        viewModel.authenticate(
+            title = "Login",
+            subTitle = "",
+            description = "",
+            negativeButtonText = "Cancel",
+            onAuthenticationOk = { okCalled = true },
+            onAuthenticationFailed = {},
+        )
+
+        // --- Assert ---
+        okCalled shouldBeEqualTo true
+    }
+
+    @Test
+    fun `authenticate should invoke onAuthenticationFailed callback when authenticator fails`() {
+        // --- Arrange ---
+        var failedCalled = false
+        val onFailedSlot = slot<() -> Unit>()
+
+        io.mockk.every {
+            biometricAuthenticator.authenticate(any(), any(), any(), any(), any(), capture(onFailedSlot))
+        } answers {
+            onFailedSlot.captured.invoke()
+        }
+
+        // --- Act ---
+        viewModel.authenticate(
+            title = "Login",
+            subTitle = "",
+            description = "",
+            negativeButtonText = "Cancel",
+            onAuthenticationOk = {},
+            onAuthenticationFailed = { failedCalled = true },
+        )
+
+        // --- Assert ---
+        failedCalled shouldBeEqualTo true
+    }
+}


### PR DESCRIPTION
## Summary

- Create `BiometricAuthenticator` interface in `domain/usecase/` — pure Kotlin, zero Android imports, fully mockable
- Create `BiometricAuthenticatorImpl` in `infrastructure/auth/` — owns all `BiometricPrompt` and `FragmentActivity` usage; registered as a Koin `factory` (never `single`) to prevent stale activity references after recreation
- Refactor `LoginViewModel`: replace `BiometricPrompt` internals with injected `BiometricAuthenticator`; rename `displayBiometricAuthenticator` → `authenticate`; no Android framework imports remain
- Update `LoginScreen`: resolve `FragmentActivity` via `LocalContext` inside composable body, pass to Koin via `parametersOf`; update call site to use named arguments
- Register `BiometricAuthenticatorImpl` factory in `helperModule` with parametric `FragmentActivity` injection
- Update `viewModelModule`: `LoginViewModel` receives its `BiometricAuthenticator` via `parametersOf`
- Add `LoginViewModelTest`: delegation test + `onAuthenticationOk` callback + `onAuthenticationFailed` callback

Closes #8

## Test plan

- [x] `LoginViewModelTest` — happy path: all params delegated to `BiometricAuthenticator`
- [x] `LoginViewModelTest` — edge case: `onAuthenticationOk` callback fires on success
- [x] `LoginViewModelTest` — edge case: `onAuthenticationFailed` callback fires on failure
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)