### PR TITLE
[ENHANCEMENT] Move UI concerns out of domain — BalanceNotifier split (issue #10)

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/helperModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/helperModule.kt
@@ -5,6 +5,7 @@ import fr.laforge.benoist.financialmanager.domain.usecase.BiometricAuthenticator
 import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationHelper
 import fr.laforge.benoist.financialmanager.infrastructure.auth.BiometricAuthenticatorImpl
 import fr.laforge.benoist.financialmanager.infrastructure.helper.NotificationHelperImpl
+import fr.laforge.benoist.financialmanager.infrastructure.notification.BalanceNotifier
 import fr.laforge.benoist.financialmanager.infrastructure.service.AndroidExportService
 import fr.laforge.benoist.financialmanager.infrastructure.service.NotificationListenerHelper
 import fr.laforge.benoist.financialmanager.presentation.util.ExportService
@@ -22,10 +23,14 @@ val helperModule by lazy {
         single<ExportService> {
             AndroidExportService(context = get())
         }
+        // NotificationHelperImpl implements both NotificationHelper (domain parsing port)
+        // and BalanceNotifier (infrastructure display port). Registering the same singleton
+        // under both interfaces avoids constructing two instances with separate state.
         single<NotificationHelper> {
-            NotificationHelperImpl(
-                context = get()
-            )
+            NotificationHelperImpl(context = get())
+        }
+        single<BalanceNotifier> {
+            get<NotificationHelper>() as NotificationHelperImpl
         }
 
         single {

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/EnableNotificationAccessUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/EnableNotificationAccessUseCase.kt
@@ -1,8 +1,23 @@
 package fr.laforge.benoist.financialmanager.domain.usecase.notification
 
+/**
+ * Application-service port for ensuring notification listener access is granted.
+ *
+ * This interface sits at the domain boundary as a driven port: it is called by the
+ * presentation layer (e.g. [MainActivityViewModel]) and implemented in the
+ * infrastructure layer ([EnableNotificationAccessUseCaseImpl]) where the Android
+ * Settings navigation actually happens.
+ *
+ * @note Intentionally placed here rather than in the domain business-rule layer because
+ * "navigate to Android Settings if permission is missing" is a system/navigation concern,
+ * not a business invariant. The interface itself remains framework-free; only the
+ * implementation touches Android APIs.
+ */
 interface EnableNotificationAccessUseCase {
+
     /**
-     * Checks if the notification acess right has been granted, and if not, displays settings
+     * Checks whether notification-listener access has been granted and, if not,
+     * opens the system Settings screen to let the user enable it.
      */
     operator fun invoke()
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationHelper.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationHelper.kt
@@ -2,20 +2,35 @@ package fr.laforge.benoist.financialmanager.domain.usecase.notification
 
 import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
 
+/**
+ * Domain port for parsing bank/payment notifications into [Transaction] objects.
+ *
+ * This interface contains only the two pure parsing operations that constitute a
+ * domain concern: deciding whether a notification text represents a transaction, and
+ * extracting a [Transaction] from the raw notification strings.
+ *
+ * Display responsibilities (e.g. showing a balance-update Android notification) are
+ * deliberately excluded — those are infrastructure/UI concerns and live in
+ * [fr.laforge.benoist.financialmanager.infrastructure.notification.BalanceNotifier].
+ */
 interface NotificationHelper {
+
     /**
-     * Indicates if a message is a transaction or not
+     * Returns whether [notificationMessage] represents a financial transaction.
      *
-     * @param notificationMessage Notification message
-     *
-     * @return Result<Boolean>
+     * @param notificationMessage The raw text body of the status-bar notification.
+     * @return [Result.success] wrapping `true` if the message looks like a transaction,
+     *   `false` otherwise. [Result.failure] on unexpected parse errors.
      */
     fun isTransaction(notificationMessage: String): Result<Boolean>
 
     /**
-     * Takes a notification message and converts it to a Transaction
+     * Parses [notificationMessage] and [notificationTitle] into a [Transaction].
+     *
+     * @param notificationTitle  The notification's title (typically the merchant name).
+     * @param notificationMessage The notification's body text containing the amount.
+     * @return [Result.success] wrapping the parsed [Transaction], or [Result.failure]
+     *   if the amount could not be extracted or is negative.
      */
     fun parseNotificationMessage(notificationTitle: String, notificationMessage: String): Result<Transaction>
-
-    fun showBalanceUpdate(newBalance: Float)
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/helper/NotificationHelper.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/helper/NotificationHelper.kt
@@ -11,8 +11,20 @@ import androidx.core.app.NotificationManagerCompat
 import fr.laforge.benoist.financialmanager.R
 import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
 import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationHelper
+import fr.laforge.benoist.financialmanager.infrastructure.notification.BalanceNotifier
 
-class NotificationHelperImpl(private val context: Context) : NotificationHelper {
+/**
+ * Concrete implementation of [NotificationHelper] (domain parsing port) and
+ * [BalanceNotifier] (infrastructure display port).
+ *
+ * Combining both in one class keeps the Android notification channel setup in a single
+ * place while respecting the interface separation: callers that only need parsing depend
+ * on [NotificationHelper]; callers that only need display depend on [BalanceNotifier].
+ *
+ * @property context Application [Context] required for notification channel creation
+ *   and permission checks.
+ */
+class NotificationHelperImpl(private val context: Context) : NotificationHelper, BalanceNotifier {
 
     override fun showBalanceUpdate(newBalance: Float) {
         // ⚠️ CRITICAL: Changed ID to force Android to register new Priority settings

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/BalanceNotifier.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/BalanceNotifier.kt
@@ -1,0 +1,25 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+/**
+ * Infrastructure port for displaying a balance-update notification to the user.
+ *
+ * This interface lives in the infrastructure layer (not the domain) because it is
+ * inherently an Android display concern — its single responsibility is to post an
+ * Android system notification whenever the user's balance changes.
+ *
+ * It was deliberately separated from
+ * [fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationHelper],
+ * which contains only pure parsing operations and must remain framework-free.
+ */
+interface BalanceNotifier {
+
+    /**
+     * Posts a heads-up system notification showing the updated account balance.
+     *
+     * @param newBalance The latest computed balance in the user's base currency.
+     *
+     * @note Implementations are responsible for permission checks (POST_NOTIFICATIONS)
+     * and notification channel creation on API 26+.
+     */
+    fun showBalanceUpdate(newBalance: Float)
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/service/NotificationListener.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/service/NotificationListener.kt
@@ -6,6 +6,7 @@ import android.service.notification.StatusBarNotification
 import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRemainingBalanceUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.notification.CreateTransactionFromNotificationUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationHelper
+import fr.laforge.benoist.financialmanager.infrastructure.notification.BalanceNotifier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -21,6 +22,7 @@ class NotificationListener : NotificationListenerService() {
     private val createTransactionFromNotificationUseCase: CreateTransactionFromNotificationUseCase by inject()
     private val getRemainingBalanceUseCase: GetRemainingBalanceUseCase by inject()
     private val notificationHelper: NotificationHelper by inject()
+    private val balanceNotifier: BalanceNotifier by inject()
     private val notificationListenerHelper: NotificationListenerHelper by inject()
 
 
@@ -73,7 +75,7 @@ class NotificationListener : NotificationListenerService() {
 
                     val newBalance = getRemainingBalanceUseCase().first()
                     withContext(Dispatchers.Main) {
-                        notificationHelper.showBalanceUpdate(newBalance)
+                        balanceNotifier.showBalanceUpdate(newBalance)
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Remove `showBalanceUpdate()` from domain `NotificationHelper` interface — the domain port now contains only pure parsing operations (`isTransaction`, `parseNotificationMessage`)
- Create `infrastructure/notification/BalanceNotifier.kt` — new infrastructure-layer interface that owns the Android notification display concern
- `NotificationHelperImpl` now implements both `NotificationHelper` and `BalanceNotifier`; Android channel/permission logic stays in one class
- `NotificationListener` injects `BalanceNotifier` separately; `notificationHelper.showBalanceUpdate()` replaced with `balanceNotifier.showBalanceUpdate()`
- `helperModule` registers `BalanceNotifier` by reusing the existing `NotificationHelperImpl` singleton (no dual instantiation)
- `EnableNotificationAccessUseCase`: KDoc clarifies it is an application-service port, not a domain business rule — the framework-free interface stays at the domain boundary per hexagonal architecture

Closes #10

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests passing (including `NotificationHelperTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)