### PR TITLE
[MINOR] Fix mutable UiState, dead call, magic constants, and KDoc typo (issue #15)

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CreateRegularTransactionsUseCaseImpl.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CreateRegularTransactionsUseCaseImpl.kt
@@ -3,6 +3,7 @@ package fr.laforge.benoist.financialmanager.domain.usecase
 import fr.laforge.benoist.financialmanager.domain.util.isInRange
 import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionPeriod
 import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
+import java.time.Month
 import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
 import fr.laforge.benoist.financialmanager.domain.util.Logger
 import kotlinx.coroutines.flow.first
@@ -63,15 +64,15 @@ class CreateRegularTransactionsUseCaseImpl(
                     if (date > endDate) {
                         logger.debug("date > endDate — date:$date endDate:$endDate")
                         month -= 1
-                        if (month == JANUARY - 1) {
-                            month = DECEMBER
+                        if (month == Month.JANUARY.value - 1) {
+                            month = Month.DECEMBER.value
                             year -= 1
                         }
                     } else {
                         logger.debug("date <= endDate")
                         month += 1
-                        if (month == DECEMBER + 1) {
-                            month = JANUARY
+                        if (month == Month.DECEMBER.value + 1) {
+                            month = Month.JANUARY.value
                             year += 1
                         }
                     }
@@ -110,8 +111,4 @@ class CreateRegularTransactionsUseCaseImpl(
         return true
     }
 
-    companion object {
-        const val JANUARY = 1
-        const val DECEMBER = 12
-    }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetMonthStartingBalanceUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetMonthStartingBalanceUseCase.kt
@@ -21,7 +21,6 @@ class GetMonthStartingBalanceUseCase(
         // We want the sum of everything BEFORE the 1st of this month at 00:00
         val startOfMonth = month.withDayOfMonth(1)
             .withHour(0).withMinute(0).withSecond(0).withNano(0)
-        repository.getTransactionsBeforeDate(startOfMonth)
         return repository.getBalanceBeforeDate(startOfMonth)
     }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetNonRecurringIncomeTransactionsUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetNonRecurringIncomeTransactionsUseCase.kt
@@ -20,7 +20,7 @@ class GetNonRecurringIncomeTransactionsUseCase(private val repository: Financial
      *
      * The logic performs the following operations:
      * 1. **Time Range**: Fetches transactions only from the 1st of the month to the 1st of the next month.
-     * 2. **Filter Type**: Must be [TransactionType.Expense].
+     * 2. **Filter Type**: Must be [TransactionType.Income].
      * 3. **Filter Periodic**: Must NOT be a template ([Transaction.isPeriodic] == false).
      * 4. **Filter Source**: Must be a manual entry ([Transaction.parent] == 0).
      * (Items with a parent ID are generated instances of a recurring bill, so we exclude them).

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/home/HomeScreenUiState.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/home/HomeScreenUiState.kt
@@ -2,6 +2,6 @@ package fr.laforge.benoist.financialmanager.presentation.ui.home
 
 data class HomeScreenUiState (
     val query: String = "",
-    var displayPeriodicDeletionDialog: Boolean = false,
+    val displayPeriodicDeletionDialog: Boolean = false,
     val displayDeleteDialog: Boolean = false,
 )


### PR DESCRIPTION
## Summary

- **`HomeScreenUiState`**: `displayPeriodicDeletionDialog` changed from `var` to `val` — all UiState properties must be immutable so mutations must go through `StateFlow.update {}`, preventing silent bypasses of the reactive stream
- **`GetMonthStartingBalanceUseCase`**: removed dead call to `repository.getTransactionsBeforeDate()` whose return value was silently discarded; only `getBalanceBeforeDate()` is used
- **`CreateRegularTransactionsUseCaseImpl`**: replaced custom `JANUARY = 1` / `DECEMBER = 12` companion constants with `java.time.Month.JANUARY.value` / `Month.DECEMBER.value`; companion object removed entirely
- **`GetNonRecurringIncomeTransactionsUseCase`**: fixed copy-paste KDoc error — filter type comment incorrectly said `TransactionType.Expense` instead of `TransactionType.Income`

Closes #15

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)