### PR TITLE
[MINOR] Document CalculateSituationProportionsUseCase formula intent (issue #17)

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/CalculateSituationProportionsUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/CalculateSituationProportionsUseCase.kt
@@ -1,21 +1,34 @@
 package fr.laforge.benoist.financialmanager.domain.usecase.indicators
 
 /**
- * A use case to calculate the proportions for the Situation Card.
+ * Use case that normalises four budget categories into proportions for the Situation Card.
+ *
+ * The Situation Card visualises how a user's monthly budget is distributed across
+ * income, recurring expenses, regular (one-off) expenses, and a savings target.
+ * Each category is expressed as a fraction of the combined total so the four values
+ * always sum to 1.0 (or all to 0.0 when the total is zero).
  */
 class CalculateSituationProportionsUseCase {
 
     /**
-     * returns a list of 4 floats representing the normalized proportions
-     * [Income, RecurringExpense, RegularExpense, Savings]
-     * Sum is always roughly 1.0 (unless total is 0).
+     * Returns a list of four floats representing the normalised proportions
+     * `[Income, RecurringExpense, RegularExpense, Savings]`.
      *
-     * @param income The total income.
-     * @param recurringExpenses The total recurring expenses.
-     * @param regularExpenses The total regular expenses.
-     * @param savingsTarget The total savings target.
+     * @param income            The user's total income for the period.
+     * @param recurringExpenses The sum of fixed/recurring expenses (e.g. rent, subscriptions).
+     * @param regularExpenses   The sum of variable one-off expenses.
+     * @param savingsTarget     The amount the user intends to save.
+     * @return A [List] of four [Float] values in the range `[0, 1]` whose sum ≈ 1.0,
+     *   or all zeros if [income], [recurringExpenses], [regularExpenses] and
+     *   [savingsTarget] are all zero.
      *
-     * @return A list of 4 floats representing the normalized proportions.
+     * @note The `total` denominator is **the sum of all four inputs**, not just the income.
+     * This is intentional: the chart shows the *relative weight* of each category within
+     * the overall budget envelope, not each category as a fraction of income alone.
+     * Example: income=50, recurringExpenses=25, regularExpenses=25, savingsTarget=0
+     * → total=100 → proportions=[0.5, 0.25, 0.25, 0.0].
+     * If you instead divided by income only, expenses > income would produce values > 1,
+     * which the chart cannot render correctly.
      */
     operator fun invoke(
         income: Float,


### PR DESCRIPTION
## Summary

- Expand KDoc on `CalculateSituationProportionsUseCase` class and `invoke()` to fully describe parameters, the return contract, and the zero-total edge case
- Add `@note` explaining **why** `total = income + recurringExpenses + regularExpenses + savingsTarget` is the correct denominator: the chart shows relative weight within the budget envelope; dividing by income alone would produce values > 1 when expenses exceed income, breaking the pie chart renderer
- The formula is confirmed correct by the existing tests — no logic change

Closes #17

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests passing (including `CalculateSituationProportionsUseCaseTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)