### PR TITLE
[TEST] Expand shallow utility tests — MathUtil, TransactionUtil, DateUtil (issue #21)

### DIFF
--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/util/DateUtilTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/util/DateUtilTest.kt
@@ -54,6 +54,13 @@ class DateUtilTest {
     }
 
     @Test
+    fun `Tests LocalDateTime next with None period returns same date`() {
+        val localDateTime = LocalDateTime.parse("2023-12-04T00:00:00")
+
+        localDateTime.next(period = TransactionPeriod.None).`should be equal to`(localDateTime)
+    }
+
+    @Test
     fun `Tests LocalDateTime getFirstDayOfMonth`() {
         val testDate = LocalDateTime.parse("2024-02-24T00:00:00")
         testDate.getFirstDayOfMonth().`should be equal to`(LocalDateTime.parse("2024-02-01T00:00:00"))
@@ -78,6 +85,22 @@ class DateUtilTest {
         val testDate = LocalDateTime.parse("2023-12-04T00:00:00")
 
         testDate.getNumberOfRemainingDaysInMonth().`should be equal to`(28)
+    }
+
+    @Test
+    fun `Tests LocalDateTime getNumberOfRemainingDaysInMonth returns 1 on last day`() {
+        val lastDayOfDec = LocalDateTime.parse("2023-12-31T00:00:00")
+
+        lastDayOfDec.getNumberOfRemainingDaysInMonth().`should be equal to`(1)
+    }
+
+    @Test
+    fun `Tests isInRange returns false on exact startDate boundary`() {
+        val startDate = LocalDateTime.parse("2023-12-22T00:00:00")
+        val endDate = LocalDateTime.parse("2024-01-23T00:00:00")
+
+        // Exactly on startDate is NOT in range (isAfter is strict)
+        startDate.isInRange(startDate, endDate).`should be false`()
     }
 
     @Test

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/util/MathUtilTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/util/MathUtilTest.kt
@@ -1,16 +1,67 @@
 package fr.laforge.benoist.financialmanager.domain.util
 
 import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldBeTrue
 import org.junit.Test
 
 class MathUtilTest {
+
     @Test
-    fun `Tests getProportion`() {
+    fun `getProportions returns correct proportions for typical budget`() {
         val income = 100F
         val recurringExpenses = 20F
         val expenses = 40F
         val savings = 10F
 
-        getProportions(income, recurringExpenses, expenses, savings).`should be equal to`(listOf(0.3F, 0.2F, 0.4F, 0.1F))
+        getProportions(income, recurringExpenses, expenses, savings)
+            .`should be equal to`(listOf(0.3F, 0.2F, 0.4F, 0.1F))
+    }
+
+    @Test
+    fun `getProportions returns all-zero remaining when expenses equal income`() {
+        // Income is fully consumed by recurring + variable + savings
+        val income = 100F
+        val recurringExpenses = 50F
+        val expenses = 30F
+        val savings = 20F
+
+        val result = getProportions(income, recurringExpenses, expenses, savings)
+
+        result[0].`should be equal to`(0f)   // remaining balance proportion
+        result[1].`should be equal to`(0.5f) // recurring
+        result[2].`should be equal to`(0.3f) // variable expenses
+        result[3].`should be equal to`(0.2f) // savings
+    }
+
+    @Test
+    fun `getProportions returns negative first element when spending exceeds income`() {
+        // Expenses and savings exceed income → first bucket (remaining) goes negative
+        val income = 100F
+        val recurringExpenses = 60F
+        val expenses = 50F
+        val savings = 10F
+
+        val result = getProportions(income, recurringExpenses, expenses, savings)
+
+        (result[0] < 0f).shouldBeTrue()  // remaining proportion is negative
+        result[1].`should be equal to`(0.6f)
+        result[2].`should be equal to`(0.5f)
+        result[3].`should be equal to`(0.1f)
+    }
+
+    @Test
+    fun `getProportions returns NaN values when income is zero`() {
+        // Division by income = 0 → Float division produces NaN for non-zero numerators
+        // and NaN for 0/0 as well; this documents current behaviour.
+        val result = getProportions(
+            income = 0F,
+            recurringExpenses = 0F,
+            expenses = 0F,
+            savings = 0F
+        )
+
+        result.forEach { value ->
+            value.isNaN().shouldBeTrue()
+        }
     }
 }

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/util/TransactionUtilTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/util/TransactionUtilTest.kt
@@ -6,9 +6,10 @@ import org.amshove.kluent.`should be equal to`
 import org.junit.Test
 
 class TransactionUtilTest {
+
     @Test
-    fun sumTest() {
-        val transactionLists = listOf(
+    fun `sum returns net balance for mixed income and expense list`() {
+        val transactions = listOf(
             Transaction(amount = 1.0F, type = TransactionType.Income),
             Transaction(amount = 1.0F, type = TransactionType.Income),
             Transaction(amount = 1.0F, type = TransactionType.Income),
@@ -21,6 +22,42 @@ class TransactionUtilTest {
             Transaction(amount = 1.0F, type = TransactionType.Income),
         )
 
-        transactionLists.sum().`should be equal to`(4.0F)
+        transactions.sum().`should be equal to`(4.0F)
+    }
+
+    @Test
+    fun `sum returns zero for empty list`() {
+        emptyList<Transaction>().sum().`should be equal to`(0.0F)
+    }
+
+    @Test
+    fun `sum returns positive total for all-income list`() {
+        val transactions = listOf(
+            Transaction(amount = 100F, type = TransactionType.Income),
+            Transaction(amount = 200F, type = TransactionType.Income),
+            Transaction(amount = 50F, type = TransactionType.Income),
+        )
+
+        transactions.sum().`should be equal to`(350F)
+    }
+
+    @Test
+    fun `sum returns negative total for all-expense list`() {
+        val transactions = listOf(
+            Transaction(amount = 100F, type = TransactionType.Expense),
+            Transaction(amount = 50F, type = TransactionType.Expense),
+        )
+
+        transactions.sum().`should be equal to`(-150F)
+    }
+
+    @Test
+    fun `sum returns zero for zero-amount transactions`() {
+        val transactions = listOf(
+            Transaction(amount = 0F, type = TransactionType.Income),
+            Transaction(amount = 0F, type = TransactionType.Expense),
+        )
+
+        transactions.sum().`should be equal to`(0F)
     }
 }


### PR DESCRIPTION
## Summary
- **MathUtilTest**: Added 3 new tests beyond the existing happy path — expenses == income (zero remaining), spending exceeds income (negative first bucket), and income == 0 (documents the NaN behaviour from dividing by income)
- **TransactionUtilTest**: Added 4 new tests — empty list, all-income list, all-expense list, and zero-amount transactions
- **DateUtilTest**: Added 3 new tests — `next(TransactionPeriod.None)` returns the same date unchanged, `getNumberOfRemainingDaysInMonth` on the last day of a month returns 1, and `isInRange` on exact `startDate` boundary returns false (strict `isAfter` semantics)

## Test plan
- [ ] `./gradlew test` passes with all new tests green
- [ ] No existing tests broken

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)