### PR TITLE
[TEST] Add unit tests for 4 untested use cases (issue #18)

### DIFF
--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetMonthStartingBalanceUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetMonthStartingBalanceUseCaseTest.kt
@@ -1,0 +1,64 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.indicators
+
+import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import java.time.LocalDateTime
+
+class GetMonthStartingBalanceUseCaseTest {
+
+    private val repository = mockk<FinancialRepository>(relaxed = true)
+    private val useCase = GetMonthStartingBalanceUseCase(repository)
+
+    @Test
+    fun `invoke calls getBalanceBeforeDate with the first instant of the given month`() = runTest {
+        // --- Arrange ---
+        val input = LocalDateTime.of(2026, 3, 15, 14, 30, 0)
+        val expectedStartOfMonth = LocalDateTime.of(2026, 3, 1, 0, 0, 0)
+
+        val dateSlot = slot<LocalDateTime>()
+        every { repository.getBalanceBeforeDate(capture(dateSlot)) } returns flowOf(500f)
+
+        // --- Act ---
+        useCase(month = input).first()
+
+        // --- Assert ---
+        dateSlot.captured shouldBeEqualTo expectedStartOfMonth
+    }
+
+    @Test
+    fun `invoke returns the balance emitted by the repository`() = runTest {
+        // --- Arrange ---
+        val expectedBalance = 1234.56f
+        every { repository.getBalanceBeforeDate(any()) } returns flowOf(expectedBalance)
+
+        // --- Act ---
+        val result = useCase(month = LocalDateTime.of(2026, 1, 1, 0, 0, 0)).first()
+
+        // --- Assert ---
+        result shouldBeEqualTo expectedBalance
+    }
+
+    @Test
+    fun `invoke on the last day of month still computes start-of-month correctly`() = runTest {
+        // --- Arrange ---
+        val lastDayOfMarch = LocalDateTime.of(2026, 3, 31, 23, 59, 59)
+        val expectedStartOfMonth = LocalDateTime.of(2026, 3, 1, 0, 0, 0)
+
+        val dateSlot = slot<LocalDateTime>()
+        every { repository.getBalanceBeforeDate(capture(dateSlot)) } returns flowOf(0f)
+
+        // --- Act ---
+        useCase(month = lastDayOfMarch).first()
+
+        // --- Assert ---
+        dateSlot.captured shouldBeEqualTo expectedStartOfMonth
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetRemainingBalanceUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetRemainingBalanceUseCaseTest.kt
@@ -1,0 +1,71 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.indicators
+
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
+import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import java.time.LocalDateTime
+
+class GetRemainingBalanceUseCaseTest {
+
+    private val repository = mockk<FinancialRepository>(relaxed = true)
+    private val useCase = GetRemainingBalanceUseCase(repository)
+
+    private val fixedDate = LocalDateTime.of(2026, 3, 15, 12, 0, 0)
+
+    @Test
+    fun `invoke returns income minus expenses for real transactions`() = runTest {
+        // --- Arrange ---
+        val salary = Transaction(uid = 1, amount = 2000f, type = TransactionType.Income, isPeriodic = false)
+        val rent = Transaction(uid = 2, amount = 800f, type = TransactionType.Expense, isPeriodic = false)
+        val groceries = Transaction(uid = 3, amount = 200f, type = TransactionType.Expense, isPeriodic = false)
+
+        every { repository.getAllInDateRange(any(), any()) } returns flowOf(
+            listOf(salary, rent, groceries)
+        )
+
+        // --- Act ---
+        val result = useCase(date = fixedDate).first()
+
+        // --- Assert ---
+        // 2000 (income) - 800 (rent) - 200 (groceries) = 1000
+        result shouldBeEqualTo 1000f
+    }
+
+    @Test
+    fun `invoke returns zero when no transactions exist for the month`() = runTest {
+        // --- Arrange ---
+        every { repository.getAllInDateRange(any(), any()) } returns flowOf(emptyList())
+
+        // --- Act ---
+        val result = useCase(date = fixedDate).first()
+
+        // --- Assert ---
+        result shouldBeEqualTo 0f
+    }
+
+    @Test
+    fun `invoke excludes periodic template transactions from the balance`() = runTest {
+        // --- Arrange ---
+        val realIncome = Transaction(uid = 1, amount = 1000f, type = TransactionType.Income, isPeriodic = false)
+        // A periodic template — should be filtered out and not affect the balance
+        val periodicTemplate = Transaction(uid = 2, amount = 500f, type = TransactionType.Income, isPeriodic = true)
+
+        every { repository.getAllInDateRange(any(), any()) } returns flowOf(
+            listOf(realIncome, periodicTemplate)
+        )
+
+        // --- Act ---
+        val result = useCase(date = fixedDate).first()
+
+        // --- Assert ---
+        // Only realIncome should count — periodicTemplate is excluded
+        result shouldBeEqualTo 1000f
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/CreateTransactionFromNotificationUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/CreateTransactionFromNotificationUseCaseTest.kt
@@ -1,0 +1,88 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class CreateTransactionFromNotificationUseCaseTest {
+
+    private val createTransactionUseCase = mockk<CreateTransactionUseCase>(relaxed = true)
+    private val notificationHelper = mockk<NotificationHelper>()
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val useCase = CreateTransactionFromNotificationUseCase(
+        createTransactionUseCase = createTransactionUseCase,
+        notificationHelper = notificationHelper,
+        dispatcher = testDispatcher
+    )
+
+    private val dummyTransaction = Transaction(uid = 1, amount = 50f, description = "Test")
+
+    @Test
+    fun `invoke creates transaction and returns true when notification is valid`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        every {
+            notificationHelper.isTransaction("€ 50.00 - Merchant")
+        } returns Result.success(true)
+        every {
+            notificationHelper.parseNotificationMessage("Merchant", "€ 50.00 - Merchant")
+        } returns Result.success(dummyTransaction)
+        coEvery { createTransactionUseCase(dummyTransaction) } returns true
+
+        // --- Act ---
+        val result = useCase(
+            notificationTitle = "Merchant",
+            notificationMessage = "€ 50.00 - Merchant"
+        )
+
+        // --- Assert ---
+        result shouldBeEqualTo true
+        coVerify(exactly = 1) { createTransactionUseCase(dummyTransaction) }
+    }
+
+    @Test
+    fun `invoke returns false and skips creation when notification is not a transaction`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        every {
+            notificationHelper.isTransaction(any())
+        } returns Result.success(false)
+
+        // --- Act ---
+        val result = useCase(
+            notificationTitle = "News App",
+            notificationMessage = "Breaking news: markets hit record"
+        )
+
+        // --- Assert ---
+        result shouldBeEqualTo false
+        coVerify(exactly = 0) { createTransactionUseCase(any()) }
+    }
+
+    @Test
+    fun `invoke returns false and skips creation when parsing fails`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        every {
+            notificationHelper.isTransaction(any())
+        } returns Result.success(true)
+        every {
+            notificationHelper.parseNotificationMessage(any(), any())
+        } returns Result.failure(IllegalArgumentException("Cannot parse amount"))
+
+        // --- Act ---
+        val result = useCase(
+            notificationTitle = "Bank",
+            notificationMessage = "Malformed message"
+        )
+
+        // --- Assert ---
+        result shouldBeEqualTo false
+        coVerify(exactly = 0) { createTransactionUseCase(any()) }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetMonthlyTransactionsUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetMonthlyTransactionsUseCaseTest.kt
@@ -1,0 +1,85 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.transaction
+
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionFilter
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
+import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+import java.time.LocalDateTime
+import java.time.YearMonth
+
+class GetMonthlyTransactionsUseCaseTest {
+
+    private val repository = mockk<FinancialRepository>(relaxed = true)
+    private val useCase = GetMonthlyTransactionsUseCase(repository)
+
+    @Test
+    fun `invoke passes correct date boundaries and non-periodic flag to the repository`() = runTest {
+        // --- Arrange ---
+        val testMonth = YearMonth.of(2026, 2)  // February — non-leap year, ends on 28th
+        val expectedStart = LocalDateTime.of(2026, 2, 1, 0, 0, 0)
+        val expectedEnd = LocalDateTime.of(2026, 2, 28, 23, 59, 59)
+
+        val filterSlot = slot<TransactionFilter>()
+        every { repository.getTransactions(capture(filterSlot)) } returns flowOf(emptyList())
+
+        // --- Act ---
+        useCase(month = testMonth).first()
+
+        // --- Assert ---
+        val captured = filterSlot.captured
+        captured.startDate shouldBeEqualTo expectedStart
+        captured.endDate shouldBeEqualTo expectedEnd
+        captured.isPeriodic shouldBeEqualTo false   // must not return periodic templates
+        captured.parentId.shouldBeNull()             // both manual and child transactions
+    }
+
+    @Test
+    fun `invoke returns transactions sorted by dateTime descending`() = runTest {
+        // --- Arrange ---
+        val older = Transaction(uid = 1, dateTime = LocalDateTime.of(2026, 3, 5, 10, 0))
+        val newer = Transaction(uid = 2, dateTime = LocalDateTime.of(2026, 3, 20, 10, 0))
+
+        every { repository.getTransactions(any()) } returns flowOf(listOf(older, newer))
+
+        // --- Act ---
+        val result = useCase(month = YearMonth.of(2026, 3)).first()
+
+        // --- Assert ---
+        result[0].uid shouldBeEqualTo newer.uid
+        result[1].uid shouldBeEqualTo older.uid
+    }
+
+    @Test
+    fun `invoke returns empty list when repository has no matching transactions`() = runTest {
+        // --- Arrange ---
+        every { repository.getTransactions(any()) } returns flowOf(emptyList())
+
+        // --- Act ---
+        val result = useCase(month = YearMonth.of(2026, 1)).first()
+
+        // --- Assert ---
+        result shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `invoke passes filterType to repository when provided`() = runTest {
+        // --- Arrange ---
+        val filterSlot = slot<TransactionFilter>()
+        every { repository.getTransactions(capture(filterSlot)) } returns flowOf(emptyList())
+
+        // --- Act ---
+        useCase(month = YearMonth.of(2026, 3), filterType = TransactionType.Expense).first()
+
+        // --- Assert ---
+        filterSlot.captured.type shouldBeEqualTo TransactionType.Expense
+    }
+}


### PR DESCRIPTION
## Summary
Created test files for four previously untested use cases:

- **`GetMonthStartingBalanceUseCaseTest`** — verifies that `getBalanceBeforeDate` is called with `day=1 / time=00:00:00` regardless of the input day, and that the balance value flows through correctly
- **`GetRemainingBalanceUseCaseTest`** — verifies income minus expenses calculation, empty list returns 0, and periodic templates are excluded from the net balance
- **`GetMonthlyTransactionsUseCaseTest`** — verifies correct date boundaries (start/end of month), transactions are returned sorted by `dateTime` descending, empty result handling, and `filterType` propagation to the repository
- **`CreateTransactionFromNotificationUseCaseTest`** — covers the three paths: valid notification → transaction created (happy path), non-transaction notification → early return false, parse failure → early return false

`GetNonRecurringIncomeUseCaseTest` already existed and was not duplicated.

## Test plan
- [ ] `./gradlew test` passes with all 4 new test files

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)