### PR TITLE
[TEST] Add unit tests for 10 untested ViewModels (issue #20)

### DIFF
--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/MainActivityViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/MainActivityViewModelTest.kt
@@ -1,0 +1,95 @@
+package fr.laforge.benoist.financialmanager.presentation.ui
+
+import fr.laforge.benoist.financialmanager.domain.usecase.CreateRegularTransactionsUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.notification.EnableNotificationAccessUseCase
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [MainActivityViewModel].
+ *
+ * @note [onStart] requires a live [androidx.navigation.NavController] to be set via
+ * [MainActivityViewModel.setNavController] before it can call `popBackStack`. Tests
+ * that would trigger `onStart` are therefore covered by instrumented (UI) tests.
+ * These unit tests focus on the business-logic delegations that can be verified
+ * without a NavController.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainActivityViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val createRegularTransactionsUseCase = mockk<CreateRegularTransactionsUseCase>(relaxed = true)
+    private val enableNotificationAccessUseCase = mockk<EnableNotificationAccessUseCase>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = MainActivityViewModel(
+        createRegularTransactionsUseCase = createRegularTransactionsUseCase,
+        enableNotificationAccessUseCase = enableNotificationAccessUseCase,
+    )
+
+    @Test
+    fun `ViewModel can be constructed without errors`() {
+        // --- Act & Assert ---
+        createViewModel() // should not throw
+    }
+
+    @Test
+    fun `enableNotificationAccessUseCase is called during onStart`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        // We need a NavController mock to call onStart without crashing on
+        // uninitialised lateinit. Since NavController is an Android framework class
+        // we use a relaxed mock so all calls are no-ops.
+        val vm = createViewModel()
+        val navController = mockk<androidx.navigation.NavController>(relaxed = true)
+        vm.setNavController(navController)
+
+        // --- Act ---
+        val owner = mockk<androidx.lifecycle.LifecycleOwner>(relaxed = true)
+        vm.onStart(owner)
+        advanceUntilIdle()
+
+        // --- Assert ---
+        verify(exactly = 1) { enableNotificationAccessUseCase() }
+    }
+
+    @Test
+    fun `createRegularTransactionsUseCase is called with current month range during onStart`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        val navController = mockk<androidx.navigation.NavController>(relaxed = true)
+        vm.setNavController(navController)
+
+        // --- Act ---
+        val owner = mockk<androidx.lifecycle.LifecycleOwner>(relaxed = true)
+        vm.onStart(owner)
+        advanceUntilIdle()
+
+        // --- Assert ---
+        coVerify(exactly = 1) {
+            createRegularTransactionsUseCase.execute(
+                startDate = match { it.dayOfMonth == 1 },   // first of month
+                endDate = any(),
+            )
+        }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/db/ImportDbViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/db/ImportDbViewModelTest.kt
@@ -1,0 +1,97 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.db
+
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.ImportTransactionsUseCase
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ImportDbViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val importTransactionsUseCase = mockk<ImportTransactionsUseCase>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = ImportDbViewModel(
+        importTransactionsUseCase = importTransactionsUseCase,
+        dispatcher = testDispatcher
+    )
+
+    // --- updateToBeImported ---
+
+    @Test
+    fun `updateToBeImported updates toBeImported state`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+        val csv = "1;12345;50.0;Coffee;Expense;false;None;0;Food"
+
+        // --- Act ---
+        vm.updateToBeImported(csv)
+
+        // --- Assert ---
+        vm.toBeImported shouldBeEqualTo csv
+    }
+
+    @Test
+    fun `updateToBeImported with empty string resets state`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+        vm.updateToBeImported("some content")
+
+        // --- Act ---
+        vm.updateToBeImported("")
+
+        // --- Assert ---
+        vm.toBeImported shouldBeEqualTo ""
+    }
+
+    // --- importDb ---
+
+    @Test
+    fun `importDb delegates toBeImported content to ImportTransactionsUseCase`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        val csv = "1;12345;50.0;Coffee;Expense;false;None;0;Food"
+        vm.updateToBeImported(csv)
+
+        // --- Act ---
+        vm.importDb()
+        advanceUntilIdle()
+
+        // --- Assert ---
+        coVerify(exactly = 1) { importTransactionsUseCase(csv) }
+    }
+
+    @Test
+    fun `importDb with empty string still delegates to ImportTransactionsUseCase`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        vm.updateToBeImported("")
+
+        // --- Act ---
+        vm.importDb()
+        advanceUntilIdle()
+
+        // --- Assert ---
+        coVerify(exactly = 1) { importTransactionsUseCase("") }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/home/situation/card/SituationCardViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/home/situation/card/SituationCardViewModelTest.kt
@@ -1,0 +1,102 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.home.situation.card
+
+import fr.laforge.benoist.financialmanager.domain.repository.PreferencesRepository
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.CalculateSituationProportionsUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetMonthStartingBalanceUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetNonRecurringIncomeUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRecurringExpensesUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRecurringIncomeUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRegularExpensesUseCase
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SituationCardViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val preferencesRepository = mockk<PreferencesRepository>()
+    private val getRecurringExpensesUseCase = mockk<GetRecurringExpensesUseCase>()
+    private val getRegularExpensesUseCase = mockk<GetRegularExpensesUseCase>()
+    private val getRecurringIncomeUseCase = mockk<GetRecurringIncomeUseCase>()
+    private val getNonRecurringIncomeUseCase = mockk<GetNonRecurringIncomeUseCase>()
+    private val getMonthStartingBalanceUseCase = mockk<GetMonthStartingBalanceUseCase>()
+    private val calculateSituationProportionsUseCase = CalculateSituationProportionsUseCase()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { preferencesRepository.getSavingTarget() } returns flowOf(0f)
+        every { getRecurringExpensesUseCase() } returns flowOf(0f)
+        every { getRegularExpensesUseCase(any()) } returns flowOf(0f)
+        every { getRecurringIncomeUseCase() } returns flowOf(0f)
+        every { getNonRecurringIncomeUseCase(any()) } returns flowOf(0f)
+        every { getMonthStartingBalanceUseCase(any()) } returns flowOf(0f)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = SituationCardViewModel(
+        preferencesRepository = preferencesRepository,
+        getRecurringExpensesUseCase = getRecurringExpensesUseCase,
+        getNonRecurringExpensesUseCase = getRegularExpensesUseCase,
+        getRecurringIncomeUseCase = getRecurringIncomeUseCase,
+        getNonRecurringIncomeUseCase = getNonRecurringIncomeUseCase,
+        getMonthStartingBalanceUseCase = getMonthStartingBalanceUseCase,
+        calculateSituationProportionsUseCase = calculateSituationProportionsUseCase,
+    )
+
+    @Test
+    fun `uiState initialises with default zero values`() = runTest(testDispatcher) {
+        // --- Arrange & Act ---
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // --- Assert ---
+        vm.uiState.value.income shouldBeEqualTo 0f
+        vm.uiState.value.savingsTarget shouldBeEqualTo 0f
+    }
+
+    @Test
+    fun `uiState reflects income from use cases`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        every { getRecurringIncomeUseCase() } returns flowOf(2000f)
+        every { getNonRecurringIncomeUseCase(any()) } returns flowOf(500f)
+
+        val vm = createViewModel()
+
+        // --- Act ---
+        advanceUntilIdle()
+
+        // --- Assert ---
+        vm.uiState.value.income shouldBeEqualTo 2500f
+    }
+
+    @Test
+    fun `uiState reflects savings target from PreferencesRepository`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        every { preferencesRepository.getSavingTarget() } returns flowOf(300f)
+        val vm = createViewModel()
+
+        // --- Act ---
+        advanceUntilIdle()
+
+        // --- Assert ---
+        vm.uiState.value.savingsTarget shouldBeEqualTo 300f
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/indicators/IndicatorsViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/indicators/IndicatorsViewModelTest.kt
@@ -1,0 +1,100 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.indicators
+
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetDailyBalanceUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetMonthStartingBalanceUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetNonRecurringIncomeUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRecurringExpensesUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRecurringIncomeUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRegularExpensesUseCase
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class IndicatorsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val getRecurringIncomeUseCase = mockk<GetRecurringIncomeUseCase>()
+    private val getRecurringExpensesUseCase = mockk<GetRecurringExpensesUseCase>()
+    private val getRegularExpensesUseCase = mockk<GetRegularExpensesUseCase>()
+    private val getDailyBalanceUseCase = mockk<GetDailyBalanceUseCase>()
+    private val getNonRecurringIncomeUseCase = mockk<GetNonRecurringIncomeUseCase>()
+    private val getMonthStartingBalanceUseCase = mockk<GetMonthStartingBalanceUseCase>()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { getRecurringIncomeUseCase() } returns flowOf(0f)
+        every { getRecurringExpensesUseCase() } returns flowOf(0f)
+        every { getRegularExpensesUseCase(any()) } returns flowOf(0f)
+        every { getDailyBalanceUseCase() } returns flowOf(emptyList())
+        every { getNonRecurringIncomeUseCase(any()) } returns flowOf(0f)
+        every { getMonthStartingBalanceUseCase(any()) } returns flowOf(0f)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = IndicatorsViewModel(
+        getRecurringIncomeUseCase = getRecurringIncomeUseCase,
+        getRecurringExpensesUseCase = getRecurringExpensesUseCase,
+        getRegularExpensesUseCase = getRegularExpensesUseCase,
+        getDailyBalanceUseCase = getDailyBalanceUseCase,
+        getNonRecurringIncomeUseCase = getNonRecurringIncomeUseCase,
+        getMonthStartingBalanceUseCase = getMonthStartingBalanceUseCase,
+    )
+
+    @Test
+    fun `ViewModel initialises with default zero values for all indicators`() = runTest(testDispatcher) {
+        // --- Arrange & Act ---
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // --- Assert ---
+        vm.recurringIncome.value shouldBeEqualTo 0f
+        vm.recurringExpenses.value shouldBeEqualTo 0f
+        vm.regularExpenses.value shouldBeEqualTo 0f
+        vm.nonRecurringIncome.value shouldBeEqualTo 0f
+        vm.startBalanceFlow.value shouldBeEqualTo 0f
+    }
+
+    @Test
+    fun `recurringIncome StateFlow reflects value emitted by use case`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        every { getRecurringIncomeUseCase() } returns flowOf(2500f)
+        val vm = createViewModel()
+
+        // --- Act ---
+        advanceUntilIdle()
+
+        // --- Assert ---
+        vm.recurringIncome.value shouldBeEqualTo 2500f
+    }
+
+    @Test
+    fun `recurringExpenses StateFlow reflects value emitted by use case`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        every { getRecurringExpensesUseCase() } returns flowOf(800f)
+        val vm = createViewModel()
+
+        // --- Act ---
+        advanceUntilIdle()
+
+        // --- Assert ---
+        vm.recurringExpenses.value shouldBeEqualTo 800f
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,122 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.settings
+
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.repository.PreferencesRepository
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.ExportTransactionsListUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetAllRecurringTransactionsUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetAllTransactionsUseCase
+import fr.laforge.benoist.financialmanager.presentation.util.ExportService
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val preferencesRepository = mockk<PreferencesRepository>(relaxed = true)
+    private val getAllTransactionsUseCase = mockk<GetAllTransactionsUseCase>()
+    private val getAllRecurringTransactionsUseCase = mockk<GetAllRecurringTransactionsUseCase>()
+    private val exportTransactionsListUseCase = mockk<ExportTransactionsListUseCase>(relaxed = true)
+    private val exportService = mockk<ExportService>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { preferencesRepository.getSavingTarget() } returns flowOf(0f)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = SettingsViewModel(
+        preferencesRepository = preferencesRepository,
+        getAllTransactionsUseCase = getAllTransactionsUseCase,
+        getAllRecurringTransactionsUseCase = getAllRecurringTransactionsUseCase,
+        exportTransactionsListUseCase = exportTransactionsListUseCase,
+        exportService = exportService,
+    )
+
+    // --- setSavingsTarget ---
+
+    @Test
+    fun `setSavingsTarget delegates to PreferencesRepository`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.setSavingsTarget(500f)
+        advanceUntilIdle()
+
+        // --- Assert ---
+        coVerify(exactly = 1) { preferencesRepository.setSavingsTarget(500f) }
+    }
+
+    @Test
+    fun `setSavingsTarget with zero is forwarded to PreferencesRepository`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.setSavingsTarget(0f)
+        advanceUntilIdle()
+
+        // --- Assert ---
+        coVerify(exactly = 1) { preferencesRepository.setSavingsTarget(0f) }
+    }
+
+    // --- saveDb ---
+
+    @Test
+    fun `saveDb fetches all transactions and triggers export service`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val transactions = listOf(
+            Transaction(uid = 1, description = "Salary"),
+            Transaction(uid = 2, description = "Rent")
+        )
+        every { getAllTransactionsUseCase() } returns flowOf(transactions)
+        every { exportTransactionsListUseCase(transactions) } returns Result.success("csv content")
+
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.saveDb()
+        advanceUntilIdle()
+
+        // --- Assert ---
+        verify(exactly = 1) { exportService.export("csv content", any()) }
+    }
+
+    @Test
+    fun `saveDb does not call export service when export use case fails`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        every { getAllTransactionsUseCase() } returns flowOf(emptyList())
+        every { exportTransactionsListUseCase(emptyList()) } returns Result.failure(
+            IllegalArgumentException("No transactions")
+        )
+
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.saveDb()
+        advanceUntilIdle()
+
+        // --- Assert ---
+        verify(exactly = 0) { exportService.export(any(), any()) }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/add/AddTransactionViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/add/AddTransactionViewModelTest.kt
@@ -1,0 +1,160 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.transaction.add
+
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionCategory
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionPeriod
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
+import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddTransactionViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val createTransactionUseCase = mockk<CreateTransactionUseCase>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = AddTransactionViewModel(createTransactionUseCase)
+
+    // --- updateAmount ---
+
+    @Test
+    fun `updateAmount updates uiState amount`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.updateAmount("42.5")
+
+        // --- Assert ---
+        vm.uiState.value.amount shouldBeEqualTo "42.5"
+    }
+
+    @Test
+    fun `updateAmount with empty string keeps uiState amount`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.updateAmount("")
+
+        // --- Assert ---
+        vm.uiState.value.amount shouldBeEqualTo ""
+    }
+
+    // --- updateDescription ---
+
+    @Test
+    fun `updateDescription updates uiState description`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.updateDescription("Coffee")
+
+        // --- Assert ---
+        vm.uiState.value.description shouldBeEqualTo "Coffee"
+    }
+
+    // --- updateInputType ---
+
+    @Test
+    fun `updateInputType updates uiState transactionType`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.updateInputType(TransactionType.Income)
+
+        // --- Assert ---
+        vm.uiState.value.transactionType shouldBeEqualTo TransactionType.Income
+    }
+
+    // --- updateTransactionCategory ---
+
+    @Test
+    fun `updateTransactionCategory updates uiState transactionCategory`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.updateTransactionCategory(TransactionCategory.Food)
+
+        // --- Assert ---
+        vm.uiState.value.transactionCategory shouldBeEqualTo TransactionCategory.Food
+    }
+
+    // --- createTransaction ---
+
+    @Test
+    fun `createTransaction delegates to CreateTransactionUseCase with current state`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        vm.updateAmount("100.0")
+        vm.updateDescription("Groceries")
+        vm.updateInputType(TransactionType.Expense)
+        vm.updateTransactionCategory(TransactionCategory.Food)
+        vm.updateIsPeriodic(false)
+        vm.updatePeriod(TransactionPeriod.Monthly)
+
+        // --- Act ---
+        vm.createTransaction()
+        advanceUntilIdle()
+
+        // --- Assert ---
+        coVerify(exactly = 1) {
+            createTransactionUseCase(
+                match { t ->
+                    t.amount == 100f &&
+                    t.description == "Groceries" &&
+                    t.type == TransactionType.Expense &&
+                    t.category == TransactionCategory.Food &&
+                    !t.isPeriodic
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `createTransaction with periodic=true sets isPeriodic and period on transaction`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        vm.updateAmount("50.0")
+        vm.updateIsPeriodic(true)
+        vm.updatePeriod(TransactionPeriod.Monthly)
+
+        // --- Act ---
+        vm.createTransaction()
+        advanceUntilIdle()
+
+        // --- Assert ---
+        coVerify(exactly = 1) {
+            createTransactionUseCase(
+                match { t ->
+                    t.isPeriodic &&
+                    t.period == TransactionPeriod.Monthly
+                }
+            )
+        }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/detail/TransactionDetailsViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/detail/TransactionDetailsViewModelTest.kt
@@ -1,0 +1,87 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.transaction.detail
+
+import androidx.lifecycle.SavedStateHandle
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetTransactionByIdUseCase
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TransactionDetailsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val savedStateHandle = mockk<SavedStateHandle>()
+    private val getTransactionByIdUseCase = mockk<GetTransactionByIdUseCase>()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = TransactionDetailsViewModel(
+        savedStateHandle = savedStateHandle,
+        getTransactionByIdUseCase = getTransactionByIdUseCase,
+    )
+
+    @Test
+    fun `uiState initialises with empty TransactionUiState before use case emits`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        every { savedStateHandle.get<Int>("transactionId") } returns null
+        every { getTransactionByIdUseCase(0) } returns flowOf(Transaction())
+
+        // --- Act ---
+        val vm = createViewModel()
+
+        // --- Assert ---
+        // initial value is empty TransactionUiState before coroutine starts
+        vm.uiState.value.transaction shouldBeEqualTo Transaction()
+    }
+
+    @Test
+    fun `uiState reflects transaction loaded by use case`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val expected = Transaction(uid = 7, description = "Salary", amount = 2000f, type = TransactionType.Income)
+        every { savedStateHandle.get<Int>("transactionId") } returns 7
+        every { getTransactionByIdUseCase(7) } returns flowOf(expected)
+
+        // --- Act ---
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // --- Assert ---
+        vm.uiState.value.transaction shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `uiState uses transactionId 0 when savedStateHandle returns null`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        every { savedStateHandle.get<Int>("transactionId") } returns null
+        val fallbackTransaction = Transaction(uid = 0)
+        every { getTransactionByIdUseCase(0) } returns flowOf(fallbackTransaction)
+
+        // --- Act ---
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // --- Assert ---
+        vm.uiState.value.transaction.uid shouldBeEqualTo 0
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/non/recurring/NonRecurringManagementViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/non/recurring/NonRecurringManagementViewModelTest.kt
@@ -1,0 +1,92 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.transaction.non.recurring
+
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.usecase.DeleteTransactionUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetNonRecurringExpenseTransactionsUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetNonRecurringIncomeTransactionsUseCase
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NonRecurringManagementViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val getNonRecurringExpenseTransactionsUseCase = mockk<GetNonRecurringExpenseTransactionsUseCase>()
+    private val getNonRecurringIncomeTransactionsUseCase = mockk<GetNonRecurringIncomeTransactionsUseCase>()
+    private val deleteTransactionUseCase = mockk<DeleteTransactionUseCase>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { getNonRecurringExpenseTransactionsUseCase() } returns flowOf(emptyList())
+        every { getNonRecurringIncomeTransactionsUseCase() } returns flowOf(emptyList())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = NonRecurringManagementViewModel(
+        getNonRecurringExpenseTransactionsUseCase = getNonRecurringExpenseTransactionsUseCase,
+        getNonRecurringIncomeTransactionsUseCase = getNonRecurringIncomeTransactionsUseCase,
+        deleteTransactionUseCase = deleteTransactionUseCase,
+    )
+
+    // --- updateSearch ---
+
+    @Test
+    fun `updateSearch updates query state`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.updateSearch("Coffee")
+
+        // --- Assert ---
+        vm.query.value shouldBeEqualTo "Coffee"
+    }
+
+    @Test
+    fun `updateSearch with empty string resets query`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+        vm.updateSearch("old")
+
+        // --- Act ---
+        vm.updateSearch("")
+
+        // --- Assert ---
+        vm.query.value shouldBeEqualTo ""
+    }
+
+    // --- deleteTransaction ---
+
+    @Test
+    fun `deleteTransaction delegates to DeleteTransactionUseCase`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        val transaction = Transaction(uid = 3, description = "Coffee")
+
+        // --- Act ---
+        vm.deleteTransaction(transaction)
+        advanceUntilIdle()
+
+        // --- Assert ---
+        coVerify(exactly = 1) { deleteTransactionUseCase(transaction) }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/recurring/RecurringManagementViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/recurring/RecurringManagementViewModelTest.kt
@@ -1,0 +1,92 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.transaction.recurring
+
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.usecase.DeleteTransactionUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetRecurringExpenseTemplatesUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetRecurringIncomeTransactionsUseCase
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RecurringManagementViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val getRecurringExpenseTemplatesUseCase = mockk<GetRecurringExpenseTemplatesUseCase>()
+    private val getRecurringIncomeTransactionsUseCase = mockk<GetRecurringIncomeTransactionsUseCase>()
+    private val deleteTransactionUseCase = mockk<DeleteTransactionUseCase>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { getRecurringExpenseTemplatesUseCase() } returns flowOf(emptyList())
+        every { getRecurringIncomeTransactionsUseCase() } returns flowOf(emptyList())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = RecurringManagementViewModel(
+        getRecurringExpenseTemplatesUseCase = getRecurringExpenseTemplatesUseCase,
+        getRecurringIncomeTransactionsUseCase = getRecurringIncomeTransactionsUseCase,
+        deleteTransactionUseCase = deleteTransactionUseCase,
+    )
+
+    // --- updateSearch ---
+
+    @Test
+    fun `updateSearch updates query state`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+
+        // --- Act ---
+        vm.updateSearch("Netflix")
+
+        // --- Assert ---
+        vm.query.value shouldBeEqualTo "Netflix"
+    }
+
+    @Test
+    fun `updateSearch with empty string resets query`() {
+        // --- Arrange ---
+        val vm = createViewModel()
+        vm.updateSearch("old")
+
+        // --- Act ---
+        vm.updateSearch("")
+
+        // --- Assert ---
+        vm.query.value shouldBeEqualTo ""
+    }
+
+    // --- deleteTransaction ---
+
+    @Test
+    fun `deleteTransaction delegates to DeleteTransactionUseCase`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        val transaction = Transaction(uid = 5, description = "Netflix")
+
+        // --- Act ---
+        vm.deleteTransaction(transaction)
+        advanceUntilIdle()
+
+        // --- Assert ---
+        coVerify(exactly = 1) { deleteTransactionUseCase(transaction) }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/update/UpdateTransactionViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/update/UpdateTransactionViewModelTest.kt
@@ -1,0 +1,171 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.transaction.update
+
+import androidx.lifecycle.SavedStateHandle
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionCategory
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
+import fr.laforge.benoist.financialmanager.domain.usecase.TransactionInteractor
+import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetTransactionByIdUseCase
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateTransactionViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val savedStateHandle = mockk<SavedStateHandle>()
+    private val getTransactionByIdUseCase = mockk<GetTransactionByIdUseCase>()
+    private val transactionInteractor = mockk<TransactionInteractor>(relaxed = true)
+
+    private val existingTransaction = Transaction(
+        uid = 42,
+        amount = 100f,
+        description = "Initial",
+        type = TransactionType.Expense
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { savedStateHandle.get<Int>("transactionId") } returns 42
+        every { savedStateHandle["transactionId"] } returns 42
+        every { getTransactionByIdUseCase(42) } returns flowOf(existingTransaction)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = UpdateTransactionViewModel(
+        savedStateHandle = savedStateHandle,
+        getTransactionByIdUseCase = getTransactionByIdUseCase,
+        transactionInteractor = transactionInteractor,
+    )
+
+    // --- updateAmount ---
+
+    @Test
+    fun `updateAmount parses string and updates uiState transaction amount`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        advanceUntilIdle() // allow init block to load transaction
+
+        // --- Act ---
+        vm.updateAmount("250.0")
+
+        // --- Assert ---
+        vm.uiState.transaction.amount shouldBeEqualTo 250f
+    }
+
+    @Test
+    fun `updateAmount silently ignores non-numeric input`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        advanceUntilIdle()
+        val amountBefore = vm.uiState.transaction.amount
+
+        // --- Act ---
+        vm.updateAmount("not-a-number")
+
+        // --- Assert ---
+        vm.uiState.transaction.amount shouldBeEqualTo amountBefore
+    }
+
+    // --- updateDescription ---
+
+    @Test
+    fun `updateDescription updates uiState transaction description`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // --- Act ---
+        vm.updateDescription("New description")
+
+        // --- Assert ---
+        vm.uiState.transaction.description shouldBeEqualTo "New description"
+    }
+
+    // --- updateInputType ---
+
+    @Test
+    fun `updateInputType updates uiState transaction type`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // --- Act ---
+        vm.updateInputType(TransactionType.Income)
+
+        // --- Assert ---
+        vm.uiState.transaction.type shouldBeEqualTo TransactionType.Income
+    }
+
+    // --- updateTransactionCategory ---
+
+    @Test
+    fun `updateTransactionCategory updates uiState transaction category`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // --- Act ---
+        vm.updateTransactionCategory(TransactionCategory.Food)
+
+        // --- Assert ---
+        vm.uiState.transaction.category shouldBeEqualTo TransactionCategory.Food
+    }
+
+    // --- isPeriodicTransaction ---
+
+    @Test
+    fun `isPeriodicTransaction delegates to TransactionInteractor`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        val periodicTransaction = Transaction(uid = 1, parent = 5)
+        every { transactionInteractor.isPeriodicTransaction(periodicTransaction) } returns true
+
+        // --- Act ---
+        val result = vm.isPeriodicTransaction(periodicTransaction)
+
+        // --- Assert ---
+        result shouldBeEqualTo true
+    }
+
+    // --- updateTransaction(dispatcher) ---
+
+    @Test
+    fun `updateTransaction delegates uiState transaction to interactor with shouldUpdateParent=false`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        advanceUntilIdle()
+        vm.updateDescription("Updated")
+
+        // --- Act ---
+        vm.updateTransaction(dispatcher = testDispatcher)
+        advanceUntilIdle()
+
+        // --- Assert ---
+        coVerify(exactly = 1) {
+            transactionInteractor.updateTransaction(
+                transaction = match { it.description == "Updated" },
+                shouldUpdateParent = false
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Added unit tests for all 10 previously untested ViewModels (LoginViewModel was done in #35):

| ViewModel | Tests | Key coverage |
|-----------|-------|-------------|
| `SettingsViewModel` | 4 | `setSavingsTarget` delegation, `saveDb` happy path + empty-export guard |
| `AddTransactionViewModel` | 7 | All state mutations + `createTransaction` for periodic/non-periodic |
| `UpdateTransactionViewModel` | 7 | All state mutations, `isPeriodicTransaction`, `updateTransaction(dispatcher)` |
| `TransactionDetailsViewModel` | 3 | uiState init, use case propagation, null id fallback |
| `ImportDbViewModel` | 4 | `updateToBeImported` state + `importDb` delegation |
| `RecurringManagementViewModel` | 3 | `updateSearch`, `deleteTransaction` delegation |
| `NonRecurringManagementViewModel` | 3 | `updateSearch`, `deleteTransaction` delegation |
| `IndicatorsViewModel` | 3 | Default zeros, `recurringIncome`/`recurringExpenses` propagation |
| `SituationCardViewModel` | 3 | Default zeros, income combination, savings target |
| `MainActivityViewModel` | 3 | Construction, `enableNotificationAccessUseCase` called in `onStart`, `createRegularTransactionsUseCase` start date is 1st of month |

All tests use `StandardTestDispatcher` + `Dispatchers.setMain/resetMain`.

## Test plan
- [ ] `./gradlew test` passes with all new tests green

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)