### PR TITLE
[DOC] Add KDoc to public domain classes and use cases (issue #23)

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/indicator/LifestyleState.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/indicator/LifestyleState.kt
@@ -1,5 +1,15 @@
 package fr.laforge.benoist.financialmanager.domain.model.indicator
 
+/**
+ * Snapshot of the user's recurring-expense lifestyle.
+ *
+ * Computed as `recurringExpenses / recurringIncome`. A [ratio] of 0.30 means
+ * 30 % of recurring income goes to fixed costs; higher values indicate less
+ * financial flexibility.
+ *
+ * @property ratio  The expense-to-income ratio (0..∞). Values > 1 mean expenses exceed income.
+ * @property status The [LifestyleStatus] band determined by [ratio].
+ */
 data class LifestyleState(
     val ratio: Float = 0f,
     val status: LifestyleStatus = LifestyleStatus.Healthy

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/transaction/Transaction.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/transaction/Transaction.kt
@@ -2,6 +2,27 @@ package fr.laforge.benoist.financialmanager.domain.model.transaction
 
 import java.time.LocalDateTime
 
+/**
+ * Core domain entity representing a single financial movement (income or expense).
+ *
+ * A [Transaction] can be either a **manual entry** (parent == 0, isPeriodic == false),
+ * a **periodic template** (isPeriodic == true), or a **generated child instance**
+ * (isPeriodic == false, parent != 0) automatically created from a template each period.
+ *
+ * @property uid       Unique database identifier. 0 for unsaved/new transactions.
+ * @property dateTime  The date and time of the transaction.
+ * @property amount    The absolute monetary value. Always positive; [type] determines
+ *                     whether it is added to or subtracted from the balance.
+ * @property description Human-readable label (e.g. "Netflix", "Salary").
+ * @property type      [TransactionType.Income] or [TransactionType.Expense].
+ * @property isPeriodic `true` when this row is a recurring-transaction **template**.
+ *                      Templates are never counted in balance calculations; they are
+ *                      used solely to generate child instances.
+ * @property period    The recurrence interval; meaningful only when [isPeriodic] is `true`.
+ * @property parent    Foreign key to the template's [uid] for generated child instances.
+ *                     0 for manual entries and templates.
+ * @property category  The budget category this transaction belongs to.
+ */
 data class Transaction(
     val uid: Int = 0,
     val dateTime: LocalDateTime = LocalDateTime.now(),

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/transaction/TransactionCategory.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/transaction/TransactionCategory.kt
@@ -1,6 +1,14 @@
 package fr.laforge.benoist.financialmanager.domain.model.transaction
 
+/**
+ * Budget category tag for a [Transaction].
+ *
+ * Categories allow users to understand where their money is going and
+ * enable category-level filtering and reporting. [None] is the default
+ * for uncategorised transactions.
+ */
 enum class TransactionCategory {
+    /** No specific category assigned. */
     None,
     Food,
     Bank,
@@ -19,8 +27,14 @@ enum class TransactionCategory {
     Telecom,
     Pet;
 
-
     companion object {
-        infix fun from(name: String): TransactionCategory? = TransactionCategory.entries.firstOrNull { it.name == name }
+        /**
+         * Returns the [TransactionCategory] whose [name] matches [name], or `null` if not found.
+         *
+         * @param name The string representation of the enum constant (case-sensitive).
+         * @return The matching [TransactionCategory], or `null` if [name] does not match any constant.
+         */
+        infix fun from(name: String): TransactionCategory? =
+            TransactionCategory.entries.firstOrNull { it.name == name }
     }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/transaction/TransactionPeriod.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/transaction/TransactionPeriod.kt
@@ -1,12 +1,31 @@
 package fr.laforge.benoist.financialmanager.domain.model.transaction
 
+/**
+ * Describes how often a periodic [Transaction] template recurs.
+ *
+ * Only meaningful when [Transaction.isPeriodic] is `true`. For one-off or child
+ * transactions the value should be [None].
+ */
 enum class TransactionPeriod {
+    /** No recurrence — used for manual entries and child instances. */
     None,
+
+    /** Recurs once per calendar month. */
     Monthly,
+
+    /** Recurs once per calendar week (every 7 days). */
     Weekly,
+
+    /** Recurs once per calendar year. */
     Yearly;
 
     companion object {
+        /**
+         * Returns the [TransactionPeriod] whose [name] matches [name], or `null` if not found.
+         *
+         * @param name The string representation of the enum constant (case-sensitive).
+         * @return The matching [TransactionPeriod], or `null` if [name] does not match any constant.
+         */
         infix fun from(name: String): TransactionPeriod? = entries.firstOrNull { it.name == name }
     }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/transaction/TransactionType.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/transaction/TransactionType.kt
@@ -1,10 +1,24 @@
 package fr.laforge.benoist.financialmanager.domain.model.transaction
 
+/**
+ * Classifies a [Transaction] as either money received or money spent.
+ *
+ * Income transactions increase the running balance; Expense transactions decrease it.
+ */
 enum class TransactionType {
+    /** Money received (salary, bonus, gift, etc.). */
     Income,
+
+    /** Money spent (rent, groceries, subscription, etc.). */
     Expense;
 
     companion object {
+        /**
+         * Returns the [TransactionType] whose [name] matches [name], or `null` if not found.
+         *
+         * @param name The string representation of the enum constant (case-sensitive).
+         * @return The matching [TransactionType], or `null` if [name] does not match any constant.
+         */
         infix fun from(name: String): TransactionType? = entries.firstOrNull { it.name == name }
     }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CheckIfTransactionIsPeriodicUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CheckIfTransactionIsPeriodicUseCase.kt
@@ -2,10 +2,29 @@ package fr.laforge.benoist.financialmanager.domain.usecase
 
 import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
 
+/**
+ * Determines whether a [Transaction] is a child of a recurring template.
+ *
+ * A transaction is considered "periodic" (i.e. generated rather than manual) when
+ * its [Transaction.parent] field is non-zero, meaning it was automatically created
+ * from a recurring template.
+ */
 interface CheckIfTransactionIsPeriodicUseCase {
+    /**
+     * @param transaction The transaction to inspect.
+     * @return `true` if [transaction] was generated from a recurring template
+     *   ([Transaction.parent] != 0); `false` for manual entries.
+     */
     operator fun invoke(transaction: Transaction): Boolean
 }
 
+/**
+ * Default implementation of [CheckIfTransactionIsPeriodicUseCase].
+ *
+ * @note The check is purely structural: a non-zero [Transaction.parent] is the
+ * canonical signal that this row was auto-generated, regardless of
+ * [Transaction.isPeriodic] (which flags templates, not child instances).
+ */
 class CheckIfTransactionIsPeriodicUseCaseImpl : CheckIfTransactionIsPeriodicUseCase {
     override fun invoke(transaction: Transaction): Boolean {
         return transaction.parent != 0

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CreateRegularTransactionsUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/CreateRegularTransactionsUseCase.kt
@@ -3,7 +3,26 @@ package fr.laforge.benoist.financialmanager.domain.usecase
 import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
 import java.time.LocalDateTime
 
+/**
+ * Application-service port for generating child transaction instances from periodic templates.
+ *
+ * Called once per period (typically on app launch) to ensure that every recurring
+ * template has a corresponding concrete child transaction inside the current date window.
+ * If a child already exists for a given template in the window, no duplicate is created.
+ */
 interface CreateRegularTransactionsUseCase {
+    /**
+     * Iterates all periodic templates and creates one child instance per template
+     * that falls inside [[startDate], [endDate]] and has no existing child yet.
+     *
+     * @param startDate   The inclusive start of the target period.
+     * @param endDate     The inclusive end of the target period.
+     * @param currentDate The reference date used to anchor the child's day-of-month.
+     *   Defaults to [LocalDateTime.now].
+     * @param type        Restricts generation to templates of a specific [TransactionType].
+     *   Defaults to [TransactionType.Expense].
+     * @return `true` when the operation completes (even if no child was created).
+     */
     suspend fun execute(
         startDate: LocalDateTime,
         endDate: LocalDateTime,

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/DeleteTransactionUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/DeleteTransactionUseCase.kt
@@ -5,18 +5,46 @@ import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
+/**
+ * Deletes a transaction and, optionally, all associated occurrences.
+ *
+ * Supports two deletion modes controlled by [DeleteTransactionType]:
+ * - [DeleteTransactionType.ThisOccurrenceOnly]: removes only the given instance.
+ * - [DeleteTransactionType.AllOccurrences]: also fetches and deletes the parent
+ *   recurring template, which stops future instances from being generated.
+ */
 interface DeleteTransactionUseCase {
+    /**
+     * Deletes [transaction] according to [deleteTransactionType].
+     *
+     * @param transaction          The transaction to remove.
+     * @param deleteTransactionType Whether to remove just this occurrence or also the
+     *   parent template (and thereby all future instances).
+     * @return [Result.success] `true` on completion. Never returns failure in the current
+     *   implementation; errors propagate as exceptions.
+     */
     suspend operator fun invoke(
         transaction: Transaction,
         deleteTransactionType: DeleteTransactionType = DeleteTransactionType.ThisOccurrenceOnly,
     ): Result<Boolean>
 }
 
+/**
+ * Controls the scope of a [DeleteTransactionUseCase] invocation.
+ */
 enum class DeleteTransactionType {
+    /** Remove only the selected transaction instance. */
     ThisOccurrenceOnly,
+
+    /** Remove the selected instance **and** its recurring parent template. */
     AllOccurrences,
 }
 
+/**
+ * Default implementation of [DeleteTransactionUseCase].
+ *
+ * @property financialRepository The [FinancialRepository] used to perform the deletions.
+ */
 class DeleteTransactionUseCaseImpl(private val financialRepository: FinancialRepository) :
     DeleteTransactionUseCase {
     override suspend fun invoke(

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetRecurringExpensesUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetRecurringExpensesUseCase.kt
@@ -5,7 +5,20 @@ import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
+/**
+ * Returns the sum of all recurring (fixed) expense transactions for the current month.
+ *
+ * Only periodic templates that match [TransactionFilter.monthlyRecurringExpenses] are
+ * included. Variable / one-off expenses are excluded; use [GetRegularExpensesUseCase]
+ * for those.
+ *
+ * @property financialRepository The [FinancialRepository] source of truth.
+ */
 class GetRecurringExpensesUseCase(private val financialRepository: FinancialRepository) {
+    /**
+     * @return A [Flow] emitting the total recurring expenses as a [Float],
+     *   updated whenever the underlying data changes.
+     */
     operator fun invoke(): Flow<Float> =
         financialRepository.getTransactions(filter = TransactionFilter.monthlyRecurringExpenses())
             .map { transactions ->

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetRemainingBalanceUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/indicators/GetRemainingBalanceUseCase.kt
@@ -6,10 +6,21 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.time.LocalDateTime
 
+/**
+ * Calculates the remaining budget balance for the month that contains [date].
+ *
+ * Formula: `(Recurring Income + Extra Income) − (Fixed Expenses + Variable Expenses)`
+ *
+ * Periodic templates ([Transaction.isPeriodic] == true) are excluded — only real
+ * money movements count.
+ *
+ * @property repository The [FinancialRepository] source of truth.
+ */
 class GetRemainingBalanceUseCase(private val repository: FinancialRepository) {
     /**
-     * Calculates the remaining balance for the month of the given [date].
-     * Formula: (Recurring Income + Extra Income) - (Fixed Expenses + Variable Expenses)
+     * @param date Reference date used to determine the month window. Defaults to now.
+     * @return A [Flow] emitting the running net balance as a [Float]. Negative values
+     *   indicate that spending exceeds income for the month.
      */
     operator fun invoke(date: LocalDateTime = LocalDateTime.now()): Flow<Float> {
         val startOfMonth = date.withDayOfMonth(1).toLocalDate().atStartOfDay()

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/CreateTransactionFromNotificationUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/CreateTransactionFromNotificationUseCase.kt
@@ -26,6 +26,14 @@ class CreateTransactionFromNotificationUseCase(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val logger: Logger = Logger.NoOp,
 ) {
+    /**
+     * Attempts to create a [Transaction] from the given notification strings.
+     *
+     * @param notificationTitle   The notification's title (typically the app or merchant name).
+     * @param notificationMessage The notification's body text, expected to contain a monetary amount.
+     * @return `true` if a transaction was successfully parsed and persisted;
+     *   `false` if the message was not a transaction or parsing failed.
+     */
     suspend operator fun invoke(notificationTitle: String, notificationMessage: String): Boolean =
         withContext(dispatcher) {
             // 1. Guard Clause: Check if it is a transaction

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetMonthlyTransactionsUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/transaction/GetMonthlyTransactionsUseCase.kt
@@ -8,9 +8,28 @@ import java.time.YearMonth
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
+/**
+ * Retrieves all concrete transactions for a given [YearMonth], optionally filtered
+ * by a text search and/or a [TransactionType].
+ *
+ * Only non-periodic (real money movement) transactions are returned — periodic
+ * templates are excluded. Both manual entries and generated recurring instances
+ * are included ([TransactionFilter.parentId] == null).
+ *
+ * @property financialRepository The [FinancialRepository] source of truth.
+ */
 class GetMonthlyTransactionsUseCase(
     private val financialRepository: FinancialRepository
 ) {
+    /**
+     * @param month       The calendar month to query.
+     * @param searchQuery Optional text filter applied against [Transaction.description]
+     *   (case-insensitive substring match). Defaults to empty (no filter).
+     * @param filterType  Optional [TransactionType] to restrict results to income or
+     *   expense only. `null` returns both types.
+     * @return A [Flow] emitting the list of matching transactions sorted by
+     *   [Transaction.dateTime] descending (most recent first).
+     */
     operator fun invoke(
         month: YearMonth,
         searchQuery: String = "",

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/util/MathUtil.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/util/MathUtil.kt
@@ -1,5 +1,26 @@
 package fr.laforge.benoist.financialmanager.domain.util
 
+/**
+ * Decomposes a budget into four proportions relative to income.
+ *
+ * Each element expresses its category as a fraction of [income]:
+ * - index 0: remaining balance ratio = `(income - recurringExpenses - expenses - savings) / income`
+ * - index 1: recurring expenses ratio = `recurringExpenses / income`
+ * - index 2: variable expenses ratio  = `expenses / income`
+ * - index 3: savings ratio            = `savings / income`
+ *
+ * @param income            Total income for the period. Must be > 0; if zero all values are NaN.
+ * @param recurringExpenses Total fixed (recurring) costs.
+ * @param expenses          Total variable (one-off) costs.
+ * @param savings           Planned savings amount.
+ * @return A [List] of four [Float] values. Values may exceed 1 or be negative when costs
+ *   exceed income.
+ *
+ * @note The denominator is [income] (not the total of all four values). This means values
+ *   show each category as a share of earned income, which can exceed 1 when spending
+ *   outstrips income. Contrast with [CalculateSituationProportionsUseCase] which uses the
+ *   sum of all inputs as the denominator.
+ */
 fun getProportions(
     income: Float,
     recurringExpenses: Float,
@@ -7,7 +28,7 @@ fun getProportions(
     savings: Float
 ): List<Float> {
     return listOf(
-        (income - (recurringExpenses + expenses + savings))/income,
+        (income - (recurringExpenses + expenses + savings)) / income,
         recurringExpenses / income,
         expenses / income,
         savings / income,

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/util/TransactionUtil.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/util/TransactionUtil.kt
@@ -8,10 +8,26 @@ import fr.laforge.benoist.financialmanager.domain.util.toLocalDateTime
 import fr.laforge.benoist.financialmanager.domain.util.toMilliseconds
 
 
+/**
+ * Serialises this [Transaction] into a semicolon-delimited CSV row.
+ *
+ * Column order: uid ; dateTime(ms) ; amount ; description ; type ; isPeriodic ; period ; parent ; category
+ *
+ * @return A single-line CSV string representation of this transaction.
+ */
 fun Transaction.exportToCsvFormat(): String {
     return "$uid;${dateTime.toMilliseconds()};$amount;$description;$type;$isPeriodic;$period;$parent;$category"
 }
 
+/**
+ * Parses a semicolon-delimited CSV row produced by [exportToCsvFormat] into a [Transaction].
+ *
+ * @param csv A single CSV line as written by [exportToCsvFormat].
+ * @return The reconstructed [Transaction].
+ * @throws NumberFormatException if numeric fields cannot be parsed.
+ * @throws NullPointerException if [TransactionType], [TransactionPeriod], or
+ *   [TransactionCategory] lookup returns `null` for an unknown value.
+ */
 fun transactionFromCsv(csv: String): Transaction {
     val split = csv.split(';')
     val uid = split[0].toInt()


### PR DESCRIPTION
## Summary
Adds KDoc to 14 domain-layer files that were missing documentation:

**Domain models**
- `Transaction` — class + all property `@property` docs explaining the template/child/manual distinction
- `TransactionType`, `TransactionPeriod`, `TransactionCategory` — enum class doc, per-value inline doc, `from()` `@param`/`@return`
- `LifestyleState` — class doc + `@property` docs

**Use cases**
- `CheckIfTransactionIsPeriodicUseCase` + Impl — `@note` explains `parent != 0` vs `isPeriodic` distinction
- `DeleteTransactionUseCase` + Impl + `DeleteTransactionType` — full KDoc including scope enum
- `CreateRegularTransactionsUseCase` — interface + `execute` `@param`/`@return`
- `GetRecurringExpensesUseCase` — class + `invoke` doc
- `GetRemainingBalanceUseCase` — class + `invoke` doc (negative value explanation)
- `GetMonthlyTransactionsUseCase` — class + `invoke` doc
- `CreateTransactionFromNotificationUseCase` — `invoke` `@param`/`@return`

**Domain utilities**
- `MathUtil.getProportions` — full KDoc with `@note` explaining income-based denominator vs `CalculateSituationProportionsUseCase`
- `TransactionUtil` — `exportToCsvFormat` + `transactionFromCsv` KDoc

## Test plan
- [ ] `./gradlew assembleDebug` passes (KDoc is compile-time safe, no runtime impact)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)