### PR TITLE
[BUGFIX] Fix HomeScreen monthly filter showing wrong transactions

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/home/HomeScreen.kt
@@ -97,9 +97,7 @@ fun HomeScreen(
                     end = 0.dp
                 )
             ) {
-                items(transactions.filter { transaction ->
-                    transaction.description.contains(uiState.query)
-                }) { transaction ->
+                items(transactions) { transaction ->
                     SwipableTransactionItem(
                         transaction = transaction,
                         isPeriodic = vm.isPeriodicTransaction(transaction),

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/home/HomeScreenViewModel.kt
@@ -94,6 +94,7 @@ class HomeScreenViewModel(
     }
 
     fun updateSearch(newVal: String) {
+        _searchQuery.value = newVal
         _uiState.update { currentState ->
             currentState.copy(query = newVal)
         }

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/update/UpdateTransactionViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/transaction/update/UpdateTransactionViewModelTest.kt
@@ -42,7 +42,6 @@ class UpdateTransactionViewModelTest {
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         every { savedStateHandle.get<Int>("transactionId") } returns 42
-        every { savedStateHandle["transactionId"] } returns 42
         every { getTransactionByIdUseCase(42) } returns flowOf(existingTransaction)
     }
 

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/views/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/views/home/HomeScreenViewModelTest.kt
@@ -12,9 +12,11 @@ import fr.laforge.benoist.financialmanager.presentation.ui.home.HomeScreenViewMo
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -73,6 +75,23 @@ class HomeScreenViewModelTest {
 
         // --- Assert ---
         vm.uiState.value.query shouldBeEqualTo "coffee"
+    }
+
+    @Test
+    fun `updateSearch propagates query to use case`() = runTest(testDispatcher) {
+        // --- Arrange ---
+        val vm = createViewModel()
+        // allTransactions uses WhileSubscribed — must have an active collector to start the flow
+        val collectJob = launch { vm.allTransactions.collect {} }
+        advanceUntilIdle()
+
+        // --- Act ---
+        vm.updateSearch("coffee")
+        advanceUntilIdle()
+
+        // --- Assert ---
+        verify { getMonthlyTransactionsUseCase(any(), "coffee", any()) }
+        collectJob.cancel()
     }
 
     @Test


### PR DESCRIPTION
Closes #55

## Summary
- `updateSearch()` was updating `_uiState.query` (client-side filter) but never propagating to `_searchQuery` (which drives `GetMonthlyTransactionsUseCase`) — the backend always ran with an empty query
- Removed the redundant client-side filter from `HomeScreen.kt`; the use case now owns search filtering end-to-end
- Fixed a pre-existing compile error in `UpdateTransactionViewModelTest` (ambiguous type on `savedStateHandle[key]`)

## Files changed
| File | Change |
|------|--------|
| `HomeScreenViewModel.kt` | `updateSearch()` now sets `_searchQuery.value` |
| `HomeScreen.kt` | Removed duplicate client-side `.filter { }` |
| `HomeScreenViewModelTest.kt` | New test: query propagates to use case |
| `UpdateTransactionViewModelTest.kt` | Remove ambiguous bracket-operator mock |

## Test plan
- [x] `HomeScreenViewModelTest` — all 8 tests pass (`./gradlew testDebugUnitTest`)
- [ ] Manual: enter a search query on HomeScreen and verify only matching current-month transactions appear
- [ ] Manual: clear the search and verify all current-month transactions reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)