### PR TITLE
[FEATURE] Display app version name in Settings screen

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/helperModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/helperModule.kt
@@ -7,6 +7,7 @@ import fr.laforge.benoist.financialmanager.infrastructure.auth.BiometricAuthenti
 import fr.laforge.benoist.financialmanager.infrastructure.helper.NotificationHelperImpl
 import fr.laforge.benoist.financialmanager.infrastructure.notification.BalanceNotifier
 import fr.laforge.benoist.financialmanager.infrastructure.service.AndroidExportService
+import fr.laforge.benoist.financialmanager.infrastructure.service.AppVersionProvider
 import fr.laforge.benoist.financialmanager.infrastructure.service.NotificationListenerHelper
 import fr.laforge.benoist.financialmanager.presentation.util.ExportService
 import org.koin.core.parameter.parametersOf
@@ -36,5 +37,7 @@ val helperModule by lazy {
         single {
             NotificationListenerHelper()
         }
+
+        single { AppVersionProvider(context = get()) }
     }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/service/AppVersionProvider.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/service/AppVersionProvider.kt
@@ -1,0 +1,24 @@
+package fr.laforge.benoist.financialmanager.infrastructure.service
+
+import android.content.Context
+
+/**
+ * Provides the application version name as declared in the build configuration.
+ *
+ * Encapsulates the [android.content.pm.PackageManager] call so that the
+ * presentation layer never depends on Android system APIs directly.
+ *
+ * @param context Application context used to query [android.content.pm.PackageManager].
+ */
+class AppVersionProvider(private val context: Context) {
+
+    /**
+     * Returns the version name of the application (e.g. `"1.0"`).
+     *
+     * @return The version name string, or `"-"` if it cannot be determined.
+     */
+    fun getVersionName(): String =
+        context.packageManager
+            .getPackageInfo(context.packageName, 0)
+            .versionName ?: "-"
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsScreen.kt
@@ -2,6 +2,8 @@ package fr.laforge.benoist.financialmanager.presentation.ui.settings
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -77,7 +79,7 @@ fun SettingsScreen(
             )
         }
     ) { innerPadding ->
-        Column(modifier = modifier.padding(innerPadding)) {
+        Column(modifier = modifier.padding(innerPadding).verticalScroll(rememberScrollState())) {
             SettingsSectionTitle(titleId = R.string.budget)
 
             OutlinedTextField(

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package fr.laforge.benoist.financialmanager.presentation.ui.settings
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -26,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -48,6 +50,8 @@ fun SettingsScreen(
 ) {
     val context = LocalContext.current
     val savingsTarget by vm.savingsTarget.collectAsState(initial = 0F)
+    val versionName = context.packageManager
+        .getPackageInfo(context.packageName, 0).versionName
 
     Scaffold(
         topBar = {
@@ -123,6 +127,30 @@ fun SettingsScreen(
             )
 
             Spacer(modifier = Modifier.height(32.dp))
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f))
+
+            SettingsSectionTitle(titleId = R.string.about)
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(id = R.string.app_version),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = versionName ?: "-",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.End
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsScreen.kt
@@ -27,9 +27,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -50,10 +50,8 @@ fun SettingsScreen(
     modifier: Modifier = Modifier,
     vm: SettingsViewModel = koinViewModel()
 ) {
-    val context = LocalContext.current
     val savingsTarget by vm.savingsTarget.collectAsState(initial = 0F)
-    val versionName = context.packageManager
-        .getPackageInfo(context.packageName, 0).versionName
+    val uiState by vm.uiState.collectAsState()
 
     Scaffold(
         topBar = {
@@ -138,7 +136,7 @@ fun SettingsScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 12.dp),
-                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
                     text = stringResource(id = R.string.app_version),
@@ -147,7 +145,7 @@ fun SettingsScreen(
                     modifier = Modifier.weight(1f)
                 )
                 Text(
-                    text = versionName ?: "-",
+                    text = uiState.versionName,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.End

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsUiState.kt
@@ -1,0 +1,10 @@
+package fr.laforge.benoist.financialmanager.presentation.ui.settings
+
+/**
+ * Immutable UI state for [SettingsScreen].
+ *
+ * @property versionName The application version name to display (e.g. `"1.0"`).
+ */
+data class SettingsUiState(
+    val versionName: String = "",
+)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsViewModel.kt
@@ -6,7 +6,11 @@ import fr.laforge.benoist.financialmanager.domain.repository.PreferencesReposito
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.ExportTransactionsListUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetAllRecurringTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetAllTransactionsUseCase
+import fr.laforge.benoist.financialmanager.infrastructure.service.AppVersionProvider
 import fr.laforge.benoist.financialmanager.presentation.util.ExportService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
@@ -17,7 +21,14 @@ class SettingsViewModel(
     private val getAllRecurringTransactionsUseCase: GetAllRecurringTransactionsUseCase,
     private val exportTransactionsListUseCase: ExportTransactionsListUseCase,
     private val exportService: ExportService,
+    private val appVersionProvider: AppVersionProvider,
 ) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SettingsUiState(versionName = appVersionProvider.getVersionName()))
+
+    /** Exposes the current [SettingsUiState] to the UI layer. */
+    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
     val savingsTarget = preferencesRepository.getSavingTarget()
 
     fun setSavingsTarget(newVal: Float) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,4 +84,8 @@
     <string name="import_db">Import database</string>
     <string name="import_db_description">Import database from a file (overwrites current data)</string>
 
+    <!-- About -->
+    <string name="about">About</string>
+    <string name="app_version">Version</string>
+
 </resources>

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/presentation/ui/settings/SettingsViewModelTest.kt
@@ -5,6 +5,7 @@ import fr.laforge.benoist.financialmanager.domain.repository.PreferencesReposito
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.ExportTransactionsListUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetAllRecurringTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetAllTransactionsUseCase
+import fr.laforge.benoist.financialmanager.infrastructure.service.AppVersionProvider
 import fr.laforge.benoist.financialmanager.presentation.util.ExportService
 import io.mockk.coVerify
 import io.mockk.every
@@ -18,6 +19,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -32,11 +34,13 @@ class SettingsViewModelTest {
     private val getAllRecurringTransactionsUseCase = mockk<GetAllRecurringTransactionsUseCase>()
     private val exportTransactionsListUseCase = mockk<ExportTransactionsListUseCase>(relaxed = true)
     private val exportService = mockk<ExportService>(relaxed = true)
+    private val appVersionProvider = mockk<AppVersionProvider>()
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         every { preferencesRepository.getSavingTarget() } returns flowOf(0f)
+        every { appVersionProvider.getVersionName() } returns "1.0"
     }
 
     @After
@@ -50,7 +54,34 @@ class SettingsViewModelTest {
         getAllRecurringTransactionsUseCase = getAllRecurringTransactionsUseCase,
         exportTransactionsListUseCase = exportTransactionsListUseCase,
         exportService = exportService,
+        appVersionProvider = appVersionProvider,
     )
+
+    // --- uiState.versionName ---
+
+    @Test
+    fun `uiState exposes version name from AppVersionProvider`() {
+        // --- Arrange ---
+        every { appVersionProvider.getVersionName() } returns "2.5"
+
+        // --- Act ---
+        val vm = createViewModel()
+
+        // --- Assert ---
+        vm.uiState.value.versionName shouldBeEqualTo "2.5"
+    }
+
+    @Test
+    fun `uiState exposes fallback when AppVersionProvider returns empty`() {
+        // --- Arrange ---
+        every { appVersionProvider.getVersionName() } returns ""
+
+        // --- Act ---
+        val vm = createViewModel()
+
+        // --- Assert ---
+        vm.uiState.value.versionName shouldBeEqualTo ""
+    }
 
     // --- setSavingsTarget ---
 


### PR DESCRIPTION
Closes #57

## Summary
- Reads the version name at runtime via `PackageManager` (no `BuildConfig` needed — it is disabled in this project)
- Adds an "About" section with a non-interactive `Version` row at the bottom of the Settings screen, following the existing section/divider pattern
- Added `about` and `app_version` string resources

## Test plan
- [ ] Build and run the app
- [ ] Navigate to Settings
- [ ] Verify a new "About" section is visible at the bottom with "Version  1.0"
- [ ] Verify the row is non-interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)