### PR TITLE
[DOMAIN] Add PendingTransaction entity and supporting enums

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/NotificationSource.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/NotificationSource.kt
@@ -1,0 +1,15 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Identifies the origin system of a financial notification.
+ *
+ * Each value maps to a known notification format that the infrastructure
+ * layer knows how to parse.
+ */
+enum class NotificationSource {
+    /** Google Pay / Google Wallet: amount before €, merchant name in title. */
+    GOOGLE_PAY,
+
+    /** Proprietary bank app: description before €, amount after €. */
+    BANK,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransaction.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransaction.kt
@@ -1,0 +1,33 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * A financial transaction detected from a notification but not yet validated by the user.
+ *
+ * A [PendingTransaction] is created whenever the notification pipeline detects a payment.
+ * Multiple notifications for the same payment (e.g. one from Google Pay and one from the
+ * bank app) are merged into a single entry whose [confidence] is upgraded to [PendingTransactionConfidence.HIGH].
+ *
+ * The entry remains [PendingTransactionStatus.PENDING] until the user either confirms it
+ * (promoting it to the main transaction history) or dismisses it (discarding it as a
+ * false positive).
+ *
+ * @property id          Unique identifier for this pending entry.
+ * @property amount      Detected payment amount in euros.
+ * @property description Merchant or payment description extracted from the notification.
+ * @property detectedAt  Timestamp of the first notification that created this entry.
+ * @property sources     All notification sources that contributed to this entry.
+ * @property confidence  Reliability level based on the number of confirming sources.
+ * @property status      Current lifecycle state of this entry.
+ */
+data class PendingTransaction(
+    val id: UUID = UUID.randomUUID(),
+    val amount: Float,
+    val description: String,
+    val detectedAt: LocalDateTime = LocalDateTime.now(),
+    val sources: List<NotificationSource>,
+    val confidence: PendingTransactionConfidence = PendingTransactionConfidence.LOW,
+    val status: PendingTransactionStatus = PendingTransactionStatus.PENDING,
+)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionConfidence.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionConfidence.kt
@@ -1,0 +1,14 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Confidence level of a [PendingTransaction] based on how many independent
+ * notification sources confirmed the same payment.
+ */
+enum class PendingTransactionConfidence {
+    /** Only one notification source detected this transaction. Requires user validation. */
+    LOW,
+
+    /** Two independent sources (e.g. Google Pay + Bank) matched the same amount within
+     *  the deduplication window. High reliability — user validation still offered. */
+    HIGH,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionStatus.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionStatus.kt
@@ -1,0 +1,15 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Lifecycle status of a [PendingTransaction] in the validation queue.
+ */
+enum class PendingTransactionStatus {
+    /** Awaiting user action. */
+    PENDING,
+
+    /** User confirmed — promoted to the main transaction history. */
+    CONFIRMED,
+
+    /** User dismissed — treated as a false positive and discarded. */
+    DISMISSED,
+}


### PR DESCRIPTION
Closes #59

## Summary
- `NotificationSource` enum — `GOOGLE_PAY` / `BANK`
- `PendingTransactionConfidence` enum — `LOW` / `HIGH`
- `PendingTransactionStatus` enum — `PENDING` / `CONFIRMED` / `DISMISSED`
- `PendingTransaction` data class — staged payment awaiting user validation

Zero Android/framework imports. Pure Kotlin domain objects.

## Test plan
- [x] `assembleDebug` passes
🤖 Generated with [Claude Code](https://claude.com/claude-code)