### PR TITLE
[DOMAIN] Implement ProcessIncomingNotificationUseCase with deduplication

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/NotificationSource.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/NotificationSource.kt
@@ -1,0 +1,15 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Identifies the origin system of a financial notification.
+ *
+ * Each value maps to a known notification format that the infrastructure
+ * layer knows how to parse.
+ */
+enum class NotificationSource {
+    /** Google Pay / Google Wallet: amount before €, merchant name in title. */
+    GOOGLE_PAY,
+
+    /** Proprietary bank app: description before €, amount after €. */
+    BANK,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/ParsedNotification.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/ParsedNotification.kt
@@ -1,0 +1,22 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+import java.time.LocalDateTime
+
+/**
+ * Normalised representation of a financial notification after parsing.
+ *
+ * This value object is produced by any [fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationParser]
+ * implementation and serves as the common language between the infrastructure
+ * parsing layer and the domain deduplication logic.
+ *
+ * @property amount      Payment amount in euros.
+ * @property description Merchant or payment description.
+ * @property source      The notification system that produced this entry.
+ * @property receivedAt  Timestamp when the notification was received.
+ */
+data class ParsedNotification(
+    val amount: Float,
+    val description: String,
+    val source: NotificationSource,
+    val receivedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransaction.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransaction.kt
@@ -1,0 +1,33 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * A financial transaction detected from a notification but not yet validated by the user.
+ *
+ * A [PendingTransaction] is created whenever the notification pipeline detects a payment.
+ * Multiple notifications for the same payment (e.g. one from Google Pay and one from the
+ * bank app) are merged into a single entry whose [confidence] is upgraded to [PendingTransactionConfidence.HIGH].
+ *
+ * The entry remains [PendingTransactionStatus.PENDING] until the user either confirms it
+ * (promoting it to the main transaction history) or dismisses it (discarding it as a
+ * false positive).
+ *
+ * @property id          Unique identifier for this pending entry.
+ * @property amount      Detected payment amount in euros.
+ * @property description Merchant or payment description extracted from the notification.
+ * @property detectedAt  Timestamp of the first notification that created this entry.
+ * @property sources     All notification sources that contributed to this entry.
+ * @property confidence  Reliability level based on the number of confirming sources.
+ * @property status      Current lifecycle state of this entry.
+ */
+data class PendingTransaction(
+    val id: UUID = UUID.randomUUID(),
+    val amount: Float,
+    val description: String,
+    val detectedAt: LocalDateTime = LocalDateTime.now(),
+    val sources: List<NotificationSource>,
+    val confidence: PendingTransactionConfidence = PendingTransactionConfidence.LOW,
+    val status: PendingTransactionStatus = PendingTransactionStatus.PENDING,
+)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionConfidence.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionConfidence.kt
@@ -1,0 +1,14 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Confidence level of a [PendingTransaction] based on how many independent
+ * notification sources confirmed the same payment.
+ */
+enum class PendingTransactionConfidence {
+    /** Only one notification source detected this transaction. Requires user validation. */
+    LOW,
+
+    /** Two independent sources (e.g. Google Pay + Bank) matched the same amount within
+     *  the deduplication window. High reliability — user validation still offered. */
+    HIGH,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionStatus.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionStatus.kt
@@ -1,0 +1,15 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Lifecycle status of a [PendingTransaction] in the validation queue.
+ */
+enum class PendingTransactionStatus {
+    /** Awaiting user action. */
+    PENDING,
+
+    /** User confirmed — promoted to the main transaction history. */
+    CONFIRMED,
+
+    /** User dismissed — treated as a false positive and discarded. */
+    DISMISSED,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/repository/PendingTransactionRepository.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/repository/PendingTransactionRepository.kt
@@ -1,0 +1,61 @@
+package fr.laforge.benoist.financialmanager.domain.repository
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Domain contract for persisting and querying [PendingTransaction] entries.
+ *
+ * @note Implementations live in the infrastructure layer and must not leak
+ *   Android or Room types through this interface.
+ */
+interface PendingTransactionRepository {
+
+    /**
+     * Persists a new [PendingTransaction].
+     *
+     * @param pendingTransaction The entry to store.
+     */
+    suspend fun add(pendingTransaction: PendingTransaction)
+
+    /**
+     * Updates an existing [PendingTransaction].
+     *
+     * @param pendingTransaction The updated entry (matched by [PendingTransaction.id]).
+     */
+    suspend fun update(pendingTransaction: PendingTransaction)
+
+    /**
+     * Returns a [Flow] emitting all [PendingTransaction] entries whose status
+     * is [PendingTransactionStatus.PENDING], ordered by [PendingTransaction.detectedAt] descending.
+     */
+    fun getAllPending(): Flow<List<PendingTransaction>>
+
+    /**
+     * Returns all [PendingTransactionStatus.PENDING] entries whose
+     * [PendingTransaction.detectedAt] falls within [from]..[to].
+     *
+     * Used by the deduplication logic to find matching entries within the
+     * configured time window.
+     *
+     * @param amount The exact amount to match.
+     * @param from   Start of the time window (inclusive).
+     * @param to     End of the time window (inclusive).
+     */
+    suspend fun findPendingByAmountInWindow(
+        amount: Float,
+        from: LocalDateTime,
+        to: LocalDateTime,
+    ): PendingTransaction?
+
+    /**
+     * Updates the [PendingTransactionStatus] of the entry identified by [id].
+     *
+     * @param id     The unique identifier of the entry.
+     * @param status The new status to apply.
+     */
+    suspend fun updateStatus(id: UUID, status: PendingTransactionStatus)
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationParser.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationParser.kt
@@ -1,0 +1,34 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+
+/**
+ * Domain contract for parsing a raw notification into a [ParsedNotification].
+ *
+ * Each implementation handles one specific notification format (e.g. Google Pay,
+ * proprietary bank). A factory in the infrastructure layer selects the correct
+ * implementation at runtime based on the notification body shape.
+ *
+ * @note Implementations must be stateless and free of Android/framework imports.
+ */
+interface NotificationParser {
+
+    /**
+     * Returns `true` if this parser can handle the given notification body.
+     *
+     * @param body The raw `android.text` string from the status-bar notification.
+     */
+    fun canParse(body: String): Boolean
+
+    /**
+     * Parses the notification into a [ParsedNotification].
+     *
+     * Must only be called after [canParse] returns `true`.
+     *
+     * @param title The notification title (typically the app or merchant name).
+     * @param body  The notification body text containing the amount.
+     * @return [Result.success] with the parsed [ParsedNotification], or
+     *   [Result.failure] if extraction fails despite [canParse] returning `true`.
+     */
+    fun parse(title: String, body: String): Result<ParsedNotification>
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCase.kt
@@ -1,0 +1,67 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+
+/**
+ * Receives a [ParsedNotification], deduplicates it against existing pending entries,
+ * and stages the result in the [PendingTransactionRepository].
+ *
+ * ## Deduplication rule
+ * If a [PendingTransaction] with the same [ParsedNotification.amount] already exists
+ * in [DEDUPLICATION_WINDOW_MINUTES], the incoming notification is treated as a second
+ * confirmation of that transaction:
+ * - The new [ParsedNotification.source] is appended to the existing entry's sources list.
+ * - Confidence is upgraded to [PendingTransactionConfidence.HIGH].
+ * - No new row is created.
+ *
+ * Otherwise a new [PendingTransaction] is inserted with [PendingTransactionConfidence.LOW].
+ *
+ * @property repository Persistence layer for pending transactions.
+ */
+class ProcessIncomingNotificationUseCase(
+    private val repository: PendingTransactionRepository,
+) {
+    /**
+     * Processes [parsed] through the deduplication pipeline and stages the result.
+     *
+     * @param parsed The normalised notification produced by a [NotificationParser].
+     */
+    suspend operator fun invoke(parsed: ParsedNotification) {
+        val windowStart = parsed.receivedAt.minusMinutes(DEDUPLICATION_WINDOW_MINUTES)
+        val windowEnd = parsed.receivedAt
+
+        val existing = repository.findPendingByAmountInWindow(
+            amount = parsed.amount,
+            from = windowStart,
+            to = windowEnd,
+        )
+
+        if (existing != null) {
+            // Merge: add source, upgrade confidence
+            val merged = existing.copy(
+                sources = (existing.sources + parsed.source).distinct(),
+                confidence = PendingTransactionConfidence.HIGH,
+            )
+            repository.update(merged)
+        } else {
+            // New entry
+            repository.add(
+                PendingTransaction(
+                    amount = parsed.amount,
+                    description = parsed.description,
+                    detectedAt = parsed.receivedAt,
+                    sources = listOf(parsed.source),
+                    confidence = PendingTransactionConfidence.LOW,
+                )
+            )
+        }
+    }
+
+    companion object {
+        /** Time window within which two notifications for the same amount are considered duplicates. */
+        const val DEDUPLICATION_WINDOW_MINUTES = 2L
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCaseTest.kt
@@ -1,0 +1,137 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
+import org.junit.Test
+import java.time.LocalDateTime
+
+class ProcessIncomingNotificationUseCaseTest {
+
+    private val repository = mockk<PendingTransactionRepository>(relaxed = true)
+    private val useCase = ProcessIncomingNotificationUseCase(repository)
+
+    private val baseTime = LocalDateTime.of(2026, 3, 1, 10, 0, 0)
+
+    // --- Happy path: new entry ---
+
+    @Test
+    fun `adds new PendingTransaction when no match exists in window`() = runTest {
+        // --- Arrange ---
+        val parsed = ParsedNotification(
+            amount = 12.50f,
+            description = "Starbucks",
+            source = NotificationSource.BANK,
+            receivedAt = baseTime,
+        )
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns null
+        val slot = slot<PendingTransaction>()
+        coEvery { repository.add(capture(slot)) } returns Unit
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        coVerify(exactly = 1) { repository.add(any()) }
+        slot.captured.amount shouldBeEqualTo 12.50f
+        slot.captured.description shouldBeEqualTo "Starbucks"
+        slot.captured.sources shouldBeEqualTo listOf(NotificationSource.BANK)
+        slot.captured.confidence shouldBeEqualTo PendingTransactionConfidence.LOW
+        slot.captured.status shouldBeEqualTo PendingTransactionStatus.PENDING
+    }
+
+    // --- Deduplication: merge ---
+
+    @Test
+    fun `merges into existing entry and upgrades confidence to HIGH when match found`() = runTest {
+        // --- Arrange ---
+        val existing = PendingTransaction(
+            amount = 12.50f,
+            description = "Starbucks",
+            detectedAt = baseTime.minusMinutes(1),
+            sources = listOf(NotificationSource.GOOGLE_PAY),
+            confidence = PendingTransactionConfidence.LOW,
+        )
+        val parsed = ParsedNotification(
+            amount = 12.50f,
+            description = "Starbucks",
+            source = NotificationSource.BANK,
+            receivedAt = baseTime,
+        )
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns existing
+        val slot = slot<PendingTransaction>()
+        coEvery { repository.update(capture(slot)) } returns Unit
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        coVerify(exactly = 0) { repository.add(any()) }
+        coVerify(exactly = 1) { repository.update(any()) }
+        slot.captured.sources shouldContain NotificationSource.GOOGLE_PAY
+        slot.captured.sources shouldContain NotificationSource.BANK
+        slot.captured.confidence shouldBeEqualTo PendingTransactionConfidence.HIGH
+    }
+
+    // --- Edge case: same source does not duplicate ---
+
+    @Test
+    fun `does not duplicate source when same source matches within window`() = runTest {
+        // --- Arrange ---
+        val existing = PendingTransaction(
+            amount = 5.00f,
+            description = "Coffee",
+            detectedAt = baseTime,
+            sources = listOf(NotificationSource.BANK),
+            confidence = PendingTransactionConfidence.LOW,
+        )
+        val parsed = ParsedNotification(
+            amount = 5.00f,
+            description = "Coffee",
+            source = NotificationSource.BANK,
+            receivedAt = baseTime.plusSeconds(30),
+        )
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns existing
+        val slot = slot<PendingTransaction>()
+        coEvery { repository.update(capture(slot)) } returns Unit
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        slot.captured.sources.size shouldBeEqualTo 1
+        slot.captured.sources shouldBeEqualTo listOf(NotificationSource.BANK)
+    }
+
+    // --- Edge case: outside window creates new entry ---
+
+    @Test
+    fun `creates new entry when matching amount is outside deduplication window`() = runTest {
+        // --- Arrange ---
+        val parsed = ParsedNotification(
+            amount = 20.00f,
+            description = "Restaurant",
+            source = NotificationSource.GOOGLE_PAY,
+            receivedAt = baseTime,
+        )
+        // Repository returns null because no match in window
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns null
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        coVerify(exactly = 1) { repository.add(any()) }
+        coVerify(exactly = 0) { repository.update(any()) }
+    }
+}


### PR DESCRIPTION
Closes #61

## Summary
- Deduplication: same amount within 2-minute window → merge sources + upgrade to `HIGH` confidence
- No match → new `PENDING` / `LOW` entry
- `DEDUPLICATION_WINDOW_MINUTES = 2L` exposed as a named constant

## Tests (4)
- New entry created when no match exists
- Merge + confidence upgrade on match
- Same source does not duplicate in sources list
- Entry outside window creates a fresh row

🤖 Generated with [Claude Code](https://claude.com/claude-code)