### PR TITLE
[INFRA] Add GooglePayNotificationParser, BankNotificationParser and NotificationParserFactory

### DIFF
--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/NotificationSource.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/NotificationSource.kt
@@ -1,0 +1,15 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Identifies the origin system of a financial notification.
+ *
+ * Each value maps to a known notification format that the infrastructure
+ * layer knows how to parse.
+ */
+enum class NotificationSource {
+    /** Google Pay / Google Wallet: amount before €, merchant name in title. */
+    GOOGLE_PAY,
+
+    /** Proprietary bank app: description before €, amount after €. */
+    BANK,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/ParsedNotification.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/ParsedNotification.kt
@@ -1,0 +1,22 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+import java.time.LocalDateTime
+
+/**
+ * Normalised representation of a financial notification after parsing.
+ *
+ * This value object is produced by any [fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationParser]
+ * implementation and serves as the common language between the infrastructure
+ * parsing layer and the domain deduplication logic.
+ *
+ * @property amount      Payment amount in euros.
+ * @property description Merchant or payment description.
+ * @property source      The notification system that produced this entry.
+ * @property receivedAt  Timestamp when the notification was received.
+ */
+data class ParsedNotification(
+    val amount: Float,
+    val description: String,
+    val source: NotificationSource,
+    val receivedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransaction.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransaction.kt
@@ -1,0 +1,33 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * A financial transaction detected from a notification but not yet validated by the user.
+ *
+ * A [PendingTransaction] is created whenever the notification pipeline detects a payment.
+ * Multiple notifications for the same payment (e.g. one from Google Pay and one from the
+ * bank app) are merged into a single entry whose [confidence] is upgraded to [PendingTransactionConfidence.HIGH].
+ *
+ * The entry remains [PendingTransactionStatus.PENDING] until the user either confirms it
+ * (promoting it to the main transaction history) or dismisses it (discarding it as a
+ * false positive).
+ *
+ * @property id          Unique identifier for this pending entry.
+ * @property amount      Detected payment amount in euros.
+ * @property description Merchant or payment description extracted from the notification.
+ * @property detectedAt  Timestamp of the first notification that created this entry.
+ * @property sources     All notification sources that contributed to this entry.
+ * @property confidence  Reliability level based on the number of confirming sources.
+ * @property status      Current lifecycle state of this entry.
+ */
+data class PendingTransaction(
+    val id: UUID = UUID.randomUUID(),
+    val amount: Float,
+    val description: String,
+    val detectedAt: LocalDateTime = LocalDateTime.now(),
+    val sources: List<NotificationSource>,
+    val confidence: PendingTransactionConfidence = PendingTransactionConfidence.LOW,
+    val status: PendingTransactionStatus = PendingTransactionStatus.PENDING,
+)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionConfidence.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionConfidence.kt
@@ -1,0 +1,14 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Confidence level of a [PendingTransaction] based on how many independent
+ * notification sources confirmed the same payment.
+ */
+enum class PendingTransactionConfidence {
+    /** Only one notification source detected this transaction. Requires user validation. */
+    LOW,
+
+    /** Two independent sources (e.g. Google Pay + Bank) matched the same amount within
+     *  the deduplication window. High reliability — user validation still offered. */
+    HIGH,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionStatus.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionStatus.kt
@@ -1,0 +1,15 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Lifecycle status of a [PendingTransaction] in the validation queue.
+ */
+enum class PendingTransactionStatus {
+    /** Awaiting user action. */
+    PENDING,
+
+    /** User confirmed — promoted to the main transaction history. */
+    CONFIRMED,
+
+    /** User dismissed — treated as a false positive and discarded. */
+    DISMISSED,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/repository/PendingTransactionRepository.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/repository/PendingTransactionRepository.kt
@@ -1,0 +1,61 @@
+package fr.laforge.benoist.financialmanager.domain.repository
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Domain contract for persisting and querying [PendingTransaction] entries.
+ *
+ * @note Implementations live in the infrastructure layer and must not leak
+ *   Android or Room types through this interface.
+ */
+interface PendingTransactionRepository {
+
+    /**
+     * Persists a new [PendingTransaction].
+     *
+     * @param pendingTransaction The entry to store.
+     */
+    suspend fun add(pendingTransaction: PendingTransaction)
+
+    /**
+     * Updates an existing [PendingTransaction].
+     *
+     * @param pendingTransaction The updated entry (matched by [PendingTransaction.id]).
+     */
+    suspend fun update(pendingTransaction: PendingTransaction)
+
+    /**
+     * Returns a [Flow] emitting all [PendingTransaction] entries whose status
+     * is [PendingTransactionStatus.PENDING], ordered by [PendingTransaction.detectedAt] descending.
+     */
+    fun getAllPending(): Flow<List<PendingTransaction>>
+
+    /**
+     * Returns all [PendingTransactionStatus.PENDING] entries whose
+     * [PendingTransaction.detectedAt] falls within [from]..[to].
+     *
+     * Used by the deduplication logic to find matching entries within the
+     * configured time window.
+     *
+     * @param amount The exact amount to match.
+     * @param from   Start of the time window (inclusive).
+     * @param to     End of the time window (inclusive).
+     */
+    suspend fun findPendingByAmountInWindow(
+        amount: Float,
+        from: LocalDateTime,
+        to: LocalDateTime,
+    ): PendingTransaction?
+
+    /**
+     * Updates the [PendingTransactionStatus] of the entry identified by [id].
+     *
+     * @param id     The unique identifier of the entry.
+     * @param status The new status to apply.
+     */
+    suspend fun updateStatus(id: UUID, status: PendingTransactionStatus)
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ConfirmPendingTransactionUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ConfirmPendingTransactionUseCase.kt
@@ -1,0 +1,42 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
+
+/**
+ * Confirms a [PendingTransaction], promoting it to the main transaction history.
+ *
+ * Steps:
+ * 1. Mark the pending entry as [PendingTransactionStatus.CONFIRMED].
+ * 2. Delegate creation of the real [Transaction] to [CreateTransactionUseCase].
+ *
+ * @property pendingRepository Repository for updating the pending entry status.
+ * @property createTransactionUseCase Use case for persisting the confirmed transaction.
+ */
+class ConfirmPendingTransactionUseCase(
+    private val pendingRepository: PendingTransactionRepository,
+    private val createTransactionUseCase: CreateTransactionUseCase,
+) {
+    /**
+     * Confirms [pendingTransaction] and creates the corresponding [Transaction].
+     *
+     * @param pendingTransaction The pending entry to confirm.
+     */
+    suspend operator fun invoke(pendingTransaction: PendingTransaction) {
+        pendingRepository.updateStatus(
+            id = pendingTransaction.id,
+            status = PendingTransactionStatus.CONFIRMED,
+        )
+        createTransactionUseCase(
+            Transaction(
+                amount = pendingTransaction.amount,
+                description = pendingTransaction.description,
+                type = TransactionType.Expense,
+            )
+        )
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/DismissPendingTransactionUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/DismissPendingTransactionUseCase.kt
@@ -1,0 +1,29 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+
+/**
+ * Dismisses a [PendingTransaction], marking it as a false positive.
+ *
+ * The entry is retained in the repository with status [PendingTransactionStatus.DISMISSED]
+ * for audit purposes but will no longer appear in the pending queue.
+ *
+ * @property repository Repository for updating the pending entry status.
+ */
+class DismissPendingTransactionUseCase(
+    private val repository: PendingTransactionRepository,
+) {
+    /**
+     * Marks [pendingTransaction] as [PendingTransactionStatus.DISMISSED].
+     *
+     * @param pendingTransaction The pending entry to dismiss.
+     */
+    suspend operator fun invoke(pendingTransaction: PendingTransaction) {
+        repository.updateStatus(
+            id = pendingTransaction.id,
+            status = PendingTransactionStatus.DISMISSED,
+        )
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationParser.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationParser.kt
@@ -1,0 +1,34 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+
+/**
+ * Domain contract for parsing a raw notification into a [ParsedNotification].
+ *
+ * Each implementation handles one specific notification format (e.g. Google Pay,
+ * proprietary bank). A factory in the infrastructure layer selects the correct
+ * implementation at runtime based on the notification body shape.
+ *
+ * @note Implementations must be stateless and free of Android/framework imports.
+ */
+interface NotificationParser {
+
+    /**
+     * Returns `true` if this parser can handle the given notification body.
+     *
+     * @param body The raw `android.text` string from the status-bar notification.
+     */
+    fun canParse(body: String): Boolean
+
+    /**
+     * Parses the notification into a [ParsedNotification].
+     *
+     * Must only be called after [canParse] returns `true`.
+     *
+     * @param title The notification title (typically the app or merchant name).
+     * @param body  The notification body text containing the amount.
+     * @return [Result.success] with the parsed [ParsedNotification], or
+     *   [Result.failure] if extraction fails despite [canParse] returning `true`.
+     */
+    fun parse(title: String, body: String): Result<ParsedNotification>
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCase.kt
@@ -1,0 +1,67 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+
+/**
+ * Receives a [ParsedNotification], deduplicates it against existing pending entries,
+ * and stages the result in the [PendingTransactionRepository].
+ *
+ * ## Deduplication rule
+ * If a [PendingTransaction] with the same [ParsedNotification.amount] already exists
+ * in [DEDUPLICATION_WINDOW_MINUTES], the incoming notification is treated as a second
+ * confirmation of that transaction:
+ * - The new [ParsedNotification.source] is appended to the existing entry's sources list.
+ * - Confidence is upgraded to [PendingTransactionConfidence.HIGH].
+ * - No new row is created.
+ *
+ * Otherwise a new [PendingTransaction] is inserted with [PendingTransactionConfidence.LOW].
+ *
+ * @property repository Persistence layer for pending transactions.
+ */
+class ProcessIncomingNotificationUseCase(
+    private val repository: PendingTransactionRepository,
+) {
+    /**
+     * Processes [parsed] through the deduplication pipeline and stages the result.
+     *
+     * @param parsed The normalised notification produced by a [NotificationParser].
+     */
+    suspend operator fun invoke(parsed: ParsedNotification) {
+        val windowStart = parsed.receivedAt.minusMinutes(DEDUPLICATION_WINDOW_MINUTES)
+        val windowEnd = parsed.receivedAt
+
+        val existing = repository.findPendingByAmountInWindow(
+            amount = parsed.amount,
+            from = windowStart,
+            to = windowEnd,
+        )
+
+        if (existing != null) {
+            // Merge: add source, upgrade confidence
+            val merged = existing.copy(
+                sources = (existing.sources + parsed.source).distinct(),
+                confidence = PendingTransactionConfidence.HIGH,
+            )
+            repository.update(merged)
+        } else {
+            // New entry
+            repository.add(
+                PendingTransaction(
+                    amount = parsed.amount,
+                    description = parsed.description,
+                    detectedAt = parsed.receivedAt,
+                    sources = listOf(parsed.source),
+                    confidence = PendingTransactionConfidence.LOW,
+                )
+            )
+        }
+    }
+
+    companion object {
+        /** Time window within which two notifications for the same amount are considered duplicates. */
+        const val DEDUPLICATION_WINDOW_MINUTES = 2L
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/BankNotificationParser.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/BankNotificationParser.kt
@@ -1,0 +1,51 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationParser
+
+/**
+ * Parses proprietary bank (Samsung Wallet) notifications.
+ *
+ * ## Format
+ * - **Title**: not used for parsing
+ * - **Body**: `"{description}€{amount}"` — description is **before** `€`,
+ *   amount is **after** `€`, comma as decimal separator
+ *   (e.g. `"Starbucks€12,50"`)
+ *
+ * Detection: the substring before `€` (trimmed) is non-numeric text.
+ */
+class BankNotificationParser : NotificationParser {
+
+    override fun canParse(body: String): Boolean {
+        if (!body.contains(EURO_SYMBOL)) return false
+        val beforeEuro = body.substringBefore(EURO_SYMBOL).trim()
+        return beforeEuro.replace(',', '.').toFloatOrNull() == null
+    }
+
+    override fun parse(title: String, body: String): Result<ParsedNotification> {
+        val parts = body.split(EURO_SYMBOL)
+        if (parts.size < 2) {
+            return Result.failure(IllegalArgumentException("Missing amount in: $body"))
+        }
+
+        val description = parts[0].trim()
+        val amountStr = parts[1].trim().replace(',', '.')
+        val amount = amountStr.toFloatOrNull()
+            ?: return Result.failure(IllegalArgumentException("Cannot parse amount from: $body"))
+
+        if (amount < 0) return Result.failure(IllegalArgumentException("Negative amount: $amount"))
+
+        return Result.success(
+            ParsedNotification(
+                amount = amount,
+                description = description,
+                source = NotificationSource.BANK,
+            )
+        )
+    }
+
+    companion object {
+        private const val EURO_SYMBOL = '€'
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/GooglePayNotificationParser.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/GooglePayNotificationParser.kt
@@ -1,0 +1,43 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationParser
+
+/**
+ * Parses Google Pay / Google Wallet notifications.
+ *
+ * ## Format
+ * - **Title**: merchant name (e.g. `"DUMMY VENDOR"`)
+ * - **Body**: `"{amount} € {any text}"` — amount is **before** `€`, comma as decimal separator
+ *   (e.g. `"10,00 € dummy string"`)
+ *
+ * Detection: the substring before `€` (trimmed) is numeric.
+ */
+class GooglePayNotificationParser : NotificationParser {
+
+    override fun canParse(body: String): Boolean {
+        val beforeEuro = body.substringBefore(EURO_SYMBOL).trim()
+        return beforeEuro.replace(',', '.').toFloatOrNull() != null
+    }
+
+    override fun parse(title: String, body: String): Result<ParsedNotification> {
+        val amountStr = body.substringBefore(EURO_SYMBOL).trim().replace(',', '.')
+        val amount = amountStr.toFloatOrNull()
+            ?: return Result.failure(IllegalArgumentException("Cannot parse amount from: $body"))
+
+        if (amount < 0) return Result.failure(IllegalArgumentException("Negative amount: $amount"))
+
+        return Result.success(
+            ParsedNotification(
+                amount = amount,
+                description = title,
+                source = NotificationSource.GOOGLE_PAY,
+            )
+        )
+    }
+
+    companion object {
+        private const val EURO_SYMBOL = '€'
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/NotificationParserFactory.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/NotificationParserFactory.kt
@@ -1,0 +1,44 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationParser
+
+/**
+ * Selects the correct [NotificationParser] for a given notification body and delegates parsing.
+ *
+ * Parsers are evaluated in priority order; the first one whose [NotificationParser.canParse]
+ * returns `true` is used. [GooglePayNotificationParser] is checked first because its format
+ * (numeric amount before `€`) is more specific than the bank format.
+ *
+ * @property parsers Ordered list of available parsers. Defaults to the two known implementations.
+ *
+ * @note Injecting [parsers] as a constructor parameter makes the factory fully testable
+ *   without relying on the Android context.
+ */
+class NotificationParserFactory(
+    private val parsers: List<NotificationParser> = listOf(
+        GooglePayNotificationParser(),
+        BankNotificationParser(),
+    )
+) {
+    /**
+     * Returns `true` if at least one registered parser can handle [body].
+     *
+     * @param body The raw notification body text.
+     */
+    fun canParse(body: String): Boolean = parsers.any { it.canParse(body) }
+
+    /**
+     * Parses [body] using the first matching parser.
+     *
+     * @param title The notification title.
+     * @param body  The notification body.
+     * @return [Result.success] with a [ParsedNotification], or [Result.failure] if no
+     *   parser matched or parsing failed.
+     */
+    fun parse(title: String, body: String): Result<ParsedNotification> {
+        val parser = parsers.firstOrNull { it.canParse(body) }
+            ?: return Result.failure(IllegalArgumentException("No parser found for: $body"))
+        return parser.parse(title, body)
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ConfirmPendingTransactionUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ConfirmPendingTransactionUseCaseTest.kt
@@ -1,0 +1,72 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.coEvery
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import java.util.UUID
+
+class ConfirmPendingTransactionUseCaseTest {
+
+    private val repository = mockk<PendingTransactionRepository>(relaxed = true)
+    private val createTransactionUseCase = mockk<CreateTransactionUseCase>(relaxed = true)
+    private val useCase = ConfirmPendingTransactionUseCase(repository, createTransactionUseCase)
+
+    private val pending = PendingTransaction(
+        id = UUID.randomUUID(),
+        amount = 25.00f,
+        description = "Supermarket",
+        sources = listOf(NotificationSource.BANK),
+        confidence = PendingTransactionConfidence.LOW,
+    )
+
+    // --- Happy path ---
+
+    @Test
+    fun `updates status to CONFIRMED and creates transaction`() = runTest {
+        // --- Act ---
+        useCase(pending)
+
+        // --- Assert ---
+        coVerify(exactly = 1) {
+            repository.updateStatus(pending.id, PendingTransactionStatus.CONFIRMED)
+        }
+        coVerify(exactly = 1) { createTransactionUseCase(any()) }
+    }
+
+    @Test
+    fun `created transaction carries amount and description from pending entry`() = runTest {
+        // --- Arrange ---
+        val slot = slot<Transaction>()
+        coEvery { createTransactionUseCase(capture(slot)) } returns true
+
+        // --- Act ---
+        useCase(pending)
+
+        // --- Assert ---
+        slot.captured.amount shouldBeEqualTo 25.00f
+        slot.captured.description shouldBeEqualTo "Supermarket"
+    }
+
+    // --- Edge case ---
+
+    @Test
+    fun `does not create transaction when repository update throws`() = runTest {
+        // --- Arrange ---
+        coEvery { repository.updateStatus(any(), any()) } throws RuntimeException("DB error")
+
+        // --- Act & Assert ---
+        try { useCase(pending) } catch (_: RuntimeException) {}
+        coVerify(exactly = 0) { createTransactionUseCase(any()) }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/DismissPendingTransactionUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/DismissPendingTransactionUseCaseTest.kt
@@ -1,0 +1,61 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.util.UUID
+
+class DismissPendingTransactionUseCaseTest {
+
+    private val repository = mockk<PendingTransactionRepository>(relaxed = true)
+    private val useCase = DismissPendingTransactionUseCase(repository)
+
+    private val pending = PendingTransaction(
+        id = UUID.randomUUID(),
+        amount = 8.50f,
+        description = "Coffee",
+        sources = listOf(NotificationSource.GOOGLE_PAY),
+        confidence = PendingTransactionConfidence.HIGH,
+    )
+
+    // --- Happy path ---
+
+    @Test
+    fun `updates status to DISMISSED`() = runTest {
+        // --- Act ---
+        useCase(pending)
+
+        // --- Assert ---
+        coVerify(exactly = 1) {
+            repository.updateStatus(pending.id, PendingTransactionStatus.DISMISSED)
+        }
+    }
+
+    // --- Edge cases ---
+
+    @Test
+    fun `does not call updateStatus with CONFIRMED`() = runTest {
+        // --- Act ---
+        useCase(pending)
+
+        // --- Assert ---
+        coVerify(exactly = 0) {
+            repository.updateStatus(any(), PendingTransactionStatus.CONFIRMED)
+        }
+    }
+
+    @Test
+    fun `calls updateStatus exactly once even for HIGH confidence entry`() = runTest {
+        // --- Act ---
+        useCase(pending.copy(confidence = PendingTransactionConfidence.HIGH))
+
+        // --- Assert ---
+        coVerify(exactly = 1) { repository.updateStatus(any(), any()) }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCaseTest.kt
@@ -1,0 +1,137 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
+import org.junit.Test
+import java.time.LocalDateTime
+
+class ProcessIncomingNotificationUseCaseTest {
+
+    private val repository = mockk<PendingTransactionRepository>(relaxed = true)
+    private val useCase = ProcessIncomingNotificationUseCase(repository)
+
+    private val baseTime = LocalDateTime.of(2026, 3, 1, 10, 0, 0)
+
+    // --- Happy path: new entry ---
+
+    @Test
+    fun `adds new PendingTransaction when no match exists in window`() = runTest {
+        // --- Arrange ---
+        val parsed = ParsedNotification(
+            amount = 12.50f,
+            description = "Starbucks",
+            source = NotificationSource.BANK,
+            receivedAt = baseTime,
+        )
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns null
+        val slot = slot<PendingTransaction>()
+        coEvery { repository.add(capture(slot)) } returns Unit
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        coVerify(exactly = 1) { repository.add(any()) }
+        slot.captured.amount shouldBeEqualTo 12.50f
+        slot.captured.description shouldBeEqualTo "Starbucks"
+        slot.captured.sources shouldBeEqualTo listOf(NotificationSource.BANK)
+        slot.captured.confidence shouldBeEqualTo PendingTransactionConfidence.LOW
+        slot.captured.status shouldBeEqualTo PendingTransactionStatus.PENDING
+    }
+
+    // --- Deduplication: merge ---
+
+    @Test
+    fun `merges into existing entry and upgrades confidence to HIGH when match found`() = runTest {
+        // --- Arrange ---
+        val existing = PendingTransaction(
+            amount = 12.50f,
+            description = "Starbucks",
+            detectedAt = baseTime.minusMinutes(1),
+            sources = listOf(NotificationSource.GOOGLE_PAY),
+            confidence = PendingTransactionConfidence.LOW,
+        )
+        val parsed = ParsedNotification(
+            amount = 12.50f,
+            description = "Starbucks",
+            source = NotificationSource.BANK,
+            receivedAt = baseTime,
+        )
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns existing
+        val slot = slot<PendingTransaction>()
+        coEvery { repository.update(capture(slot)) } returns Unit
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        coVerify(exactly = 0) { repository.add(any()) }
+        coVerify(exactly = 1) { repository.update(any()) }
+        slot.captured.sources shouldContain NotificationSource.GOOGLE_PAY
+        slot.captured.sources shouldContain NotificationSource.BANK
+        slot.captured.confidence shouldBeEqualTo PendingTransactionConfidence.HIGH
+    }
+
+    // --- Edge case: same source does not duplicate ---
+
+    @Test
+    fun `does not duplicate source when same source matches within window`() = runTest {
+        // --- Arrange ---
+        val existing = PendingTransaction(
+            amount = 5.00f,
+            description = "Coffee",
+            detectedAt = baseTime,
+            sources = listOf(NotificationSource.BANK),
+            confidence = PendingTransactionConfidence.LOW,
+        )
+        val parsed = ParsedNotification(
+            amount = 5.00f,
+            description = "Coffee",
+            source = NotificationSource.BANK,
+            receivedAt = baseTime.plusSeconds(30),
+        )
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns existing
+        val slot = slot<PendingTransaction>()
+        coEvery { repository.update(capture(slot)) } returns Unit
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        slot.captured.sources.size shouldBeEqualTo 1
+        slot.captured.sources shouldBeEqualTo listOf(NotificationSource.BANK)
+    }
+
+    // --- Edge case: outside window creates new entry ---
+
+    @Test
+    fun `creates new entry when matching amount is outside deduplication window`() = runTest {
+        // --- Arrange ---
+        val parsed = ParsedNotification(
+            amount = 20.00f,
+            description = "Restaurant",
+            source = NotificationSource.GOOGLE_PAY,
+            receivedAt = baseTime,
+        )
+        // Repository returns null because no match in window
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns null
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        coVerify(exactly = 1) { repository.add(any()) }
+        coVerify(exactly = 0) { repository.update(any()) }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/BankNotificationParserTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/BankNotificationParserTest.kt
@@ -1,0 +1,61 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should be equal to`
+import org.junit.Test
+
+class BankNotificationParserTest {
+
+    private val parser = BankNotificationParser()
+
+    // --- canParse ---
+
+    @Test
+    fun `canParse returns true for valid bank format`() {
+        parser.canParse("Starbucks€12,50") `should be` true
+    }
+
+    @Test
+    fun `canParse returns false for Google Pay format`() {
+        parser.canParse("10,00 € dummy string") `should be` false
+    }
+
+    @Test
+    fun `canParse returns false when no euro symbol present`() {
+        parser.canParse("no euro here") `should be` false
+    }
+
+    // --- parse: happy path ---
+
+    @Test
+    fun `parse extracts description and amount correctly`() {
+        val result = parser.parse("ignored title", "Starbucks€12,50")
+        result.isSuccess `should be` true
+        result.getOrNull()?.amount `should be equal to` 12.50f
+        result.getOrNull()?.description `should be equal to` "Starbucks"
+        result.getOrNull()?.source `should be equal to` NotificationSource.BANK
+    }
+
+    @Test
+    fun `parse trims whitespace from description and amount`() {
+        val result = parser.parse("ignored", " Coffee Shop €3,00")
+        result.isSuccess `should be` true
+        result.getOrNull()?.description `should be equal to` "Coffee Shop"
+        result.getOrNull()?.amount `should be equal to` 3.00f
+    }
+
+    // --- parse: edge cases ---
+
+    @Test
+    fun `parse returns failure for negative amount`() {
+        val result = parser.parse("ignored", "Starbucks€-12,50")
+        result.isFailure `should be` true
+    }
+
+    @Test
+    fun `parse returns failure when amount is missing`() {
+        val result = parser.parse("ignored", "NoAmountHere")
+        result.isFailure `should be` true
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/GooglePayNotificationParserTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/GooglePayNotificationParserTest.kt
@@ -1,0 +1,60 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should be equal to`
+import org.junit.Test
+
+class GooglePayNotificationParserTest {
+
+    private val parser = GooglePayNotificationParser()
+
+    // --- canParse ---
+
+    @Test
+    fun `canParse returns true for valid Google Pay format`() {
+        parser.canParse("10,00 € dummy string") `should be` true
+    }
+
+    @Test
+    fun `canParse returns false for bank format`() {
+        parser.canParse("Starbucks€12,50") `should be` false
+    }
+
+    @Test
+    fun `canParse returns false when no euro symbol present`() {
+        parser.canParse("no euro here") `should be` false
+    }
+
+    // --- parse: happy path ---
+
+    @Test
+    fun `parse extracts amount and title correctly`() {
+        val result = parser.parse("DUMMY VENDOR", "10,00 € dummy string")
+        result.isSuccess `should be` true
+        result.getOrNull()?.amount `should be equal to` 10.00f
+        result.getOrNull()?.description `should be equal to` "DUMMY VENDOR"
+        result.getOrNull()?.source `should be equal to` NotificationSource.GOOGLE_PAY
+    }
+
+    @Test
+    fun `parse handles amount without trailing text`() {
+        val result = parser.parse("Shop", "5,99€")
+        result.isSuccess `should be` true
+        result.getOrNull()?.amount `should be equal to` 5.99f
+    }
+
+    // --- parse: edge cases ---
+
+    @Test
+    fun `parse returns failure for negative amount`() {
+        val result = parser.parse("VENDOR", "-10,00 € refund")
+        result.isFailure `should be` true
+    }
+
+    @Test
+    fun `parse returns failure when amount is not parseable`() {
+        val result = parser.parse("VENDOR", "abc€rest")
+        result.isFailure `should be` true
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/NotificationParserFactoryTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/NotificationParserFactoryTest.kt
@@ -1,0 +1,50 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should be equal to`
+import org.junit.Test
+
+class NotificationParserFactoryTest {
+
+    private val factory = NotificationParserFactory()
+
+    // --- canParse ---
+
+    @Test
+    fun `canParse returns true for Google Pay format`() {
+        factory.canParse("10,00 € some text") `should be` true
+    }
+
+    @Test
+    fun `canParse returns true for bank format`() {
+        factory.canParse("Starbucks€12,50") `should be` true
+    }
+
+    @Test
+    fun `canParse returns false for unrecognised format`() {
+        factory.canParse("no euro sign here") `should be` false
+    }
+
+    // --- parse: routes to correct parser ---
+
+    @Test
+    fun `parse routes Google Pay notification to GooglePayNotificationParser`() {
+        val result = factory.parse("VENDOR", "10,00 € some text")
+        result.isSuccess `should be` true
+        result.getOrNull()?.source `should be equal to` NotificationSource.GOOGLE_PAY
+    }
+
+    @Test
+    fun `parse routes bank notification to BankNotificationParser`() {
+        val result = factory.parse("ignored", "Starbucks€12,50")
+        result.isSuccess `should be` true
+        result.getOrNull()?.source `should be equal to` NotificationSource.BANK
+    }
+
+    @Test
+    fun `parse returns failure for unrecognised format`() {
+        val result = factory.parse("title", "no euro sign here")
+        result.isFailure `should be` true
+    }
+}


### PR DESCRIPTION
Closes #63

## Summary
- `GooglePayNotificationParser`: amount before `€`, merchant from title
- `BankNotificationParser`: description before `€`, amount after `€`
- `NotificationParserFactory`: priority-ordered selection via `canParse`

## Detection heuristic
Substring before `€` is numeric → Google Pay. Text → Bank.

## Tests (20)
- `canParse` for each parser + factory
- `parse` happy paths with amount/description/source assertions
- Negative amounts, missing amounts, unrecognised format

🤖 Generated with [Claude Code](https://claude.com/claude-code)