### PR TITLE
GH-66: Wire DI bindings for PendingTransaction pipeline

### DIFF
--- a/app/schemas/fr.laforge.benoist.financialmanager.infrastructure.repository.database.AppDatabase/3.json
+++ b/app/schemas/fr.laforge.benoist.financialmanager.infrastructure.repository.database.AppDatabase/3.json
@@ -1,0 +1,139 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "8ba60ac8cbcd51ea106b37632020a88e",
+    "entities": [
+      {
+        "tableName": "TransactionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `date_time` INTEGER NOT NULL, `amount` REAL NOT NULL, `type` TEXT NOT NULL, `description` TEXT NOT NULL, `is_periodic` INTEGER NOT NULL, `period` TEXT NOT NULL, `parent` INTEGER NOT NULL, `category` TEXT NOT NULL DEFAULT 'None')",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPeriodic",
+            "columnName": "is_periodic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "period",
+            "columnName": "period",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'None'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pending_transaction",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `amount` REAL NOT NULL, `description` TEXT NOT NULL, `detected_at` INTEGER NOT NULL, `sources` TEXT NOT NULL, `confidence` TEXT NOT NULL, `status` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detectedAt",
+            "columnName": "detected_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sources",
+            "columnName": "sources",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8ba60ac8cbcd51ea106b37632020a88e')"
+    ]
+  }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/repositoryModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/repositoryModule.kt
@@ -2,17 +2,30 @@ package fr.laforge.benoist.financialmanager.di.module
 
 import androidx.room.Room
 import fr.laforge.benoist.financialmanager.domain.repository.FinancialRepository
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
 import fr.laforge.benoist.financialmanager.infrastructure.repository.AndroidFinancialRepository
+import fr.laforge.benoist.financialmanager.infrastructure.repository.RoomPendingTransactionRepository
 import fr.laforge.benoist.financialmanager.infrastructure.repository.database.AppDatabase
 import org.koin.dsl.module
 
 val repositoryModule by lazy {
     module {
-        single { Room.databaseBuilder(
+        // Single AppDatabase instance shared by all DAOs. MIGRATION_2_3 is registered
+        // manually because AutoMigration is incompatible with Room KSP 2.3.4 for this schema.
+        single {
+            Room.databaseBuilder(
                 get(),
-                AppDatabase::class.java, "database-name"
-            ).build().getFinancialInputDao()
+                AppDatabase::class.java,
+                "database-name",
+            )
+                .addMigrations(AppDatabase.MIGRATION_2_3)
+                .build()
         }
+
+        single { get<AppDatabase>().getFinancialInputDao() }
+        single { get<AppDatabase>().getPendingTransactionDao() }
+
         single<FinancialRepository> { AndroidFinancialRepository(get()) }
+        single<PendingTransactionRepository> { RoomPendingTransactionRepository(dao = get()) }
     }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/useCaseModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/useCaseModule.kt
@@ -20,8 +20,11 @@ import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRecurrin
 import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRecurringIncomeUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRegularExpensesUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.indicators.GetRemainingBalanceUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.notification.ConfirmPendingTransactionUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.notification.CreateTransactionFromNotificationUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.notification.DismissPendingTransactionUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.notification.EnableNotificationAccessUseCase
+import fr.laforge.benoist.financialmanager.domain.usecase.notification.ProcessIncomingNotificationUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.ExportTransactionsListUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetAllRecurringTransactionsUseCase
 import fr.laforge.benoist.financialmanager.domain.usecase.transaction.GetAllTransactionsUseCase
@@ -53,6 +56,9 @@ val useCaseModule by lazy {
             CreateRegularTransactionsUseCaseImpl(repository = get(), logger = get())
         }
         factory<EnableNotificationAccessUseCase> { EnableNotificationAccessUseCaseImpl(context = get()) }
+        factory { ProcessIncomingNotificationUseCase(repository = get()) }
+        factory { ConfirmPendingTransactionUseCase(pendingRepository = get(), createTransactionUseCase = get()) }
+        factory { DismissPendingTransactionUseCase(repository = get()) }
         factory {
             CreateTransactionFromNotificationUseCase(
                 processIncomingNotificationUseCase = get(),

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/useCaseModule.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/di/module/useCaseModule.kt
@@ -55,7 +55,7 @@ val useCaseModule by lazy {
         factory<EnableNotificationAccessUseCase> { EnableNotificationAccessUseCaseImpl(context = get()) }
         factory {
             CreateTransactionFromNotificationUseCase(
-                createTransactionUseCase = get(),
+                processIncomingNotificationUseCase = get(),
                 notificationHelper = get(),
                 logger = get(),
             )

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/NotificationSource.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/NotificationSource.kt
@@ -1,0 +1,15 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Identifies the origin system of a financial notification.
+ *
+ * Each value maps to a known notification format that the infrastructure
+ * layer knows how to parse.
+ */
+enum class NotificationSource {
+    /** Google Pay / Google Wallet: amount before €, merchant name in title. */
+    GOOGLE_PAY,
+
+    /** Proprietary bank app: description before €, amount after €. */
+    BANK,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/ParsedNotification.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/ParsedNotification.kt
@@ -1,0 +1,22 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+import java.time.LocalDateTime
+
+/**
+ * Normalised representation of a financial notification after parsing.
+ *
+ * This value object is produced by any [fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationParser]
+ * implementation and serves as the common language between the infrastructure
+ * parsing layer and the domain deduplication logic.
+ *
+ * @property amount      Payment amount in euros.
+ * @property description Merchant or payment description.
+ * @property source      The notification system that produced this entry.
+ * @property receivedAt  Timestamp when the notification was received.
+ */
+data class ParsedNotification(
+    val amount: Float,
+    val description: String,
+    val source: NotificationSource,
+    val receivedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransaction.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransaction.kt
@@ -1,0 +1,33 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * A financial transaction detected from a notification but not yet validated by the user.
+ *
+ * A [PendingTransaction] is created whenever the notification pipeline detects a payment.
+ * Multiple notifications for the same payment (e.g. one from Google Pay and one from the
+ * bank app) are merged into a single entry whose [confidence] is upgraded to [PendingTransactionConfidence.HIGH].
+ *
+ * The entry remains [PendingTransactionStatus.PENDING] until the user either confirms it
+ * (promoting it to the main transaction history) or dismisses it (discarding it as a
+ * false positive).
+ *
+ * @property id          Unique identifier for this pending entry.
+ * @property amount      Detected payment amount in euros.
+ * @property description Merchant or payment description extracted from the notification.
+ * @property detectedAt  Timestamp of the first notification that created this entry.
+ * @property sources     All notification sources that contributed to this entry.
+ * @property confidence  Reliability level based on the number of confirming sources.
+ * @property status      Current lifecycle state of this entry.
+ */
+data class PendingTransaction(
+    val id: UUID = UUID.randomUUID(),
+    val amount: Float,
+    val description: String,
+    val detectedAt: LocalDateTime = LocalDateTime.now(),
+    val sources: List<NotificationSource>,
+    val confidence: PendingTransactionConfidence = PendingTransactionConfidence.LOW,
+    val status: PendingTransactionStatus = PendingTransactionStatus.PENDING,
+)

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionConfidence.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionConfidence.kt
@@ -1,0 +1,14 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Confidence level of a [PendingTransaction] based on how many independent
+ * notification sources confirmed the same payment.
+ */
+enum class PendingTransactionConfidence {
+    /** Only one notification source detected this transaction. Requires user validation. */
+    LOW,
+
+    /** Two independent sources (e.g. Google Pay + Bank) matched the same amount within
+     *  the deduplication window. High reliability — user validation still offered. */
+    HIGH,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionStatus.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/model/notification/PendingTransactionStatus.kt
@@ -1,0 +1,15 @@
+package fr.laforge.benoist.financialmanager.domain.model.notification
+
+/**
+ * Lifecycle status of a [PendingTransaction] in the validation queue.
+ */
+enum class PendingTransactionStatus {
+    /** Awaiting user action. */
+    PENDING,
+
+    /** User confirmed — promoted to the main transaction history. */
+    CONFIRMED,
+
+    /** User dismissed — treated as a false positive and discarded. */
+    DISMISSED,
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/repository/PendingTransactionRepository.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/repository/PendingTransactionRepository.kt
@@ -1,0 +1,61 @@
+package fr.laforge.benoist.financialmanager.domain.repository
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Domain contract for persisting and querying [PendingTransaction] entries.
+ *
+ * @note Implementations live in the infrastructure layer and must not leak
+ *   Android or Room types through this interface.
+ */
+interface PendingTransactionRepository {
+
+    /**
+     * Persists a new [PendingTransaction].
+     *
+     * @param pendingTransaction The entry to store.
+     */
+    suspend fun add(pendingTransaction: PendingTransaction)
+
+    /**
+     * Updates an existing [PendingTransaction].
+     *
+     * @param pendingTransaction The updated entry (matched by [PendingTransaction.id]).
+     */
+    suspend fun update(pendingTransaction: PendingTransaction)
+
+    /**
+     * Returns a [Flow] emitting all [PendingTransaction] entries whose status
+     * is [PendingTransactionStatus.PENDING], ordered by [PendingTransaction.detectedAt] descending.
+     */
+    fun getAllPending(): Flow<List<PendingTransaction>>
+
+    /**
+     * Returns all [PendingTransactionStatus.PENDING] entries whose
+     * [PendingTransaction.detectedAt] falls within [from]..[to].
+     *
+     * Used by the deduplication logic to find matching entries within the
+     * configured time window.
+     *
+     * @param amount The exact amount to match.
+     * @param from   Start of the time window (inclusive).
+     * @param to     End of the time window (inclusive).
+     */
+    suspend fun findPendingByAmountInWindow(
+        amount: Float,
+        from: LocalDateTime,
+        to: LocalDateTime,
+    ): PendingTransaction?
+
+    /**
+     * Updates the [PendingTransactionStatus] of the entry identified by [id].
+     *
+     * @param id     The unique identifier of the entry.
+     * @param status The new status to apply.
+     */
+    suspend fun updateStatus(id: UUID, status: PendingTransactionStatus)
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ConfirmPendingTransactionUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ConfirmPendingTransactionUseCase.kt
@@ -1,0 +1,42 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.model.transaction.TransactionType
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
+
+/**
+ * Confirms a [PendingTransaction], promoting it to the main transaction history.
+ *
+ * Steps:
+ * 1. Mark the pending entry as [PendingTransactionStatus.CONFIRMED].
+ * 2. Delegate creation of the real [Transaction] to [CreateTransactionUseCase].
+ *
+ * @property pendingRepository Repository for updating the pending entry status.
+ * @property createTransactionUseCase Use case for persisting the confirmed transaction.
+ */
+class ConfirmPendingTransactionUseCase(
+    private val pendingRepository: PendingTransactionRepository,
+    private val createTransactionUseCase: CreateTransactionUseCase,
+) {
+    /**
+     * Confirms [pendingTransaction] and creates the corresponding [Transaction].
+     *
+     * @param pendingTransaction The pending entry to confirm.
+     */
+    suspend operator fun invoke(pendingTransaction: PendingTransaction) {
+        pendingRepository.updateStatus(
+            id = pendingTransaction.id,
+            status = PendingTransactionStatus.CONFIRMED,
+        )
+        createTransactionUseCase(
+            Transaction(
+                amount = pendingTransaction.amount,
+                description = pendingTransaction.description,
+                type = TransactionType.Expense,
+            )
+        )
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/CreateTransactionFromNotificationUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/CreateTransactionFromNotificationUseCase.kt
@@ -1,43 +1,43 @@
 package fr.laforge.benoist.financialmanager.domain.usecase.notification
 
-import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
 import fr.laforge.benoist.financialmanager.domain.util.Logger
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
- * Use case that creates a [Transaction] from an incoming notification payload.
+ * Use case that stages an incoming notification as a
+ * [fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction]
+ * for later user confirmation or dismissal.
  *
- * Orchestrates notification validation, parsing, and persistence by delegating
- * to [NotificationHelper] and [CreateTransactionUseCase]. Returns `true` when
- * a transaction was successfully created, `false` for any non-fatal failure
- * (unrecognised notification, parse error).
+ * Orchestrates notification detection, parsing, and deduplication by delegating to
+ * [NotificationHelper] and [ProcessIncomingNotificationUseCase].
+ * Returns `true` when the notification was successfully staged, `false` for any non-fatal
+ * failure (unrecognised notification, parse error).
  *
- * @property createTransactionUseCase Persists the parsed transaction.
- * @property notificationHelper Validates and parses the raw notification strings.
- * @property dispatcher Coroutine dispatcher for the blocking parse/persist work.
+ * @property processIncomingNotificationUseCase Stages the parsed notification with deduplication.
+ * @property notificationHelper Detects and parses raw notification strings.
+ * @property dispatcher Coroutine dispatcher for the parse/persist work.
  *   Defaults to [Dispatchers.IO]; override in tests for determinism.
  * @property logger Domain [Logger] for diagnostic output. Defaults to [Logger.NoOp].
  */
 class CreateTransactionFromNotificationUseCase(
-    private val createTransactionUseCase: CreateTransactionUseCase,
+    private val processIncomingNotificationUseCase: ProcessIncomingNotificationUseCase,
     private val notificationHelper: NotificationHelper,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val logger: Logger = Logger.NoOp,
 ) {
     /**
-     * Attempts to create a [Transaction] from the given notification strings.
+     * Attempts to stage a pending transaction from the given notification strings.
      *
      * @param notificationTitle   The notification's title (typically the app or merchant name).
      * @param notificationMessage The notification's body text, expected to contain a monetary amount.
-     * @return `true` if a transaction was successfully parsed and persisted;
+     * @return `true` if a pending transaction was successfully staged;
      *   `false` if the message was not a transaction or parsing failed.
      */
     suspend operator fun invoke(notificationTitle: String, notificationMessage: String): Boolean =
         withContext(dispatcher) {
-            // 1. Guard Clause: Check if it is a transaction
-            // .getOrDefault(false) is cleaner than comparing == Result.success(true)
+            // 1. Guard: decide whether this notification contains a transaction
             val isTransaction = notificationHelper.isTransaction(notificationMessage)
                 .getOrDefault(false)
 
@@ -46,24 +46,23 @@ class CreateTransactionFromNotificationUseCase(
                 return@withContext false
             }
 
-            // 2. Parse the message
-            val transactionResult = notificationHelper.parseNotificationMessage(
+            // 2. Parse into a ParsedNotification (preserves source for deduplication)
+            val parsedResult = notificationHelper.parseToPending(
                 notificationTitle = notificationTitle,
-                notificationMessage = notificationMessage
+                notificationMessage = notificationMessage,
             )
 
-            // 3. Guard Clause: Check if parsing succeeded
-            val transaction = transactionResult.getOrNull()
-            if (transaction == null) {
+            val parsed = parsedResult.getOrNull()
+            if (parsed == null) {
                 logger.error(
-                    message = "Failed to parse transaction",
-                    throwable = transactionResult.exceptionOrNull()
+                    message = "Failed to parse notification",
+                    throwable = parsedResult.exceptionOrNull(),
                 )
                 return@withContext false
             }
 
-            // 4. Happy Path: Create transaction and return success
-            createTransactionUseCase(transaction)
+            // 3. Stage the parsed notification (deduplication handled inside)
+            processIncomingNotificationUseCase(parsed)
             true
         }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/DismissPendingTransactionUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/DismissPendingTransactionUseCase.kt
@@ -1,0 +1,29 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+
+/**
+ * Dismisses a [PendingTransaction], marking it as a false positive.
+ *
+ * The entry is retained in the repository with status [PendingTransactionStatus.DISMISSED]
+ * for audit purposes but will no longer appear in the pending queue.
+ *
+ * @property repository Repository for updating the pending entry status.
+ */
+class DismissPendingTransactionUseCase(
+    private val repository: PendingTransactionRepository,
+) {
+    /**
+     * Marks [pendingTransaction] as [PendingTransactionStatus.DISMISSED].
+     *
+     * @param pendingTransaction The pending entry to dismiss.
+     */
+    suspend operator fun invoke(pendingTransaction: PendingTransaction) {
+        repository.updateStatus(
+            id = pendingTransaction.id,
+            status = PendingTransactionStatus.DISMISSED,
+        )
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationHelper.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationHelper.kt
@@ -1,13 +1,12 @@
 package fr.laforge.benoist.financialmanager.domain.usecase.notification
 
-import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
 
 /**
- * Domain port for parsing bank/payment notifications into [Transaction] objects.
+ * Domain port for detecting and parsing bank/payment notifications.
  *
- * This interface contains only the two pure parsing operations that constitute a
- * domain concern: deciding whether a notification text represents a transaction, and
- * extracting a [Transaction] from the raw notification strings.
+ * Implementations delegate to a parser registry (e.g. [NotificationParserFactory][fr.laforge.benoist.financialmanager.infrastructure.notification.NotificationParserFactory])
+ * that handles multiple notification formats (Google Pay, bank proprietary, etc.).
  *
  * Display responsibilities (e.g. showing a balance-update Android notification) are
  * deliberately excluded — those are infrastructure/UI concerns and live in
@@ -16,21 +15,26 @@ import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
 interface NotificationHelper {
 
     /**
-     * Returns whether [notificationMessage] represents a financial transaction.
+     * Returns whether [notificationMessage] represents a financial transaction
+     * that can be parsed by the underlying parser registry.
      *
      * @param notificationMessage The raw text body of the status-bar notification.
      * @return [Result.success] wrapping `true` if the message looks like a transaction,
-     *   `false` otherwise. [Result.failure] on unexpected parse errors.
+     *   `false` otherwise. [Result.failure] on unexpected errors.
      */
     fun isTransaction(notificationMessage: String): Result<Boolean>
 
     /**
-     * Parses [notificationMessage] and [notificationTitle] into a [Transaction].
+     * Parses [notificationMessage] and [notificationTitle] into a [ParsedNotification].
      *
-     * @param notificationTitle  The notification's title (typically the merchant name).
+     * Unlike the previous [Transaction]-based parsing, this method preserves the
+     * originating [fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource]
+     * so that the deduplication pipeline can merge duplicate notifications.
+     *
+     * @param notificationTitle   The notification's title (typically the merchant name).
      * @param notificationMessage The notification's body text containing the amount.
-     * @return [Result.success] wrapping the parsed [Transaction], or [Result.failure]
-     *   if the amount could not be extracted or is negative.
+     * @return [Result.success] wrapping the parsed [ParsedNotification], or [Result.failure]
+     *   if no registered parser can handle the message.
      */
-    fun parseNotificationMessage(notificationTitle: String, notificationMessage: String): Result<Transaction>
+    fun parseToPending(notificationTitle: String, notificationMessage: String): Result<ParsedNotification>
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationParser.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationParser.kt
@@ -1,0 +1,34 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+
+/**
+ * Domain contract for parsing a raw notification into a [ParsedNotification].
+ *
+ * Each implementation handles one specific notification format (e.g. Google Pay,
+ * proprietary bank). A factory in the infrastructure layer selects the correct
+ * implementation at runtime based on the notification body shape.
+ *
+ * @note Implementations must be stateless and free of Android/framework imports.
+ */
+interface NotificationParser {
+
+    /**
+     * Returns `true` if this parser can handle the given notification body.
+     *
+     * @param body The raw `android.text` string from the status-bar notification.
+     */
+    fun canParse(body: String): Boolean
+
+    /**
+     * Parses the notification into a [ParsedNotification].
+     *
+     * Must only be called after [canParse] returns `true`.
+     *
+     * @param title The notification title (typically the app or merchant name).
+     * @param body  The notification body text containing the amount.
+     * @return [Result.success] with the parsed [ParsedNotification], or
+     *   [Result.failure] if extraction fails despite [canParse] returning `true`.
+     */
+    fun parse(title: String, body: String): Result<ParsedNotification>
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCase.kt
@@ -1,0 +1,67 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+
+/**
+ * Receives a [ParsedNotification], deduplicates it against existing pending entries,
+ * and stages the result in the [PendingTransactionRepository].
+ *
+ * ## Deduplication rule
+ * If a [PendingTransaction] with the same [ParsedNotification.amount] already exists
+ * in [DEDUPLICATION_WINDOW_MINUTES], the incoming notification is treated as a second
+ * confirmation of that transaction:
+ * - The new [ParsedNotification.source] is appended to the existing entry's sources list.
+ * - Confidence is upgraded to [PendingTransactionConfidence.HIGH].
+ * - No new row is created.
+ *
+ * Otherwise a new [PendingTransaction] is inserted with [PendingTransactionConfidence.LOW].
+ *
+ * @property repository Persistence layer for pending transactions.
+ */
+class ProcessIncomingNotificationUseCase(
+    private val repository: PendingTransactionRepository,
+) {
+    /**
+     * Processes [parsed] through the deduplication pipeline and stages the result.
+     *
+     * @param parsed The normalised notification produced by a [NotificationParser].
+     */
+    suspend operator fun invoke(parsed: ParsedNotification) {
+        val windowStart = parsed.receivedAt.minusMinutes(DEDUPLICATION_WINDOW_MINUTES)
+        val windowEnd = parsed.receivedAt
+
+        val existing = repository.findPendingByAmountInWindow(
+            amount = parsed.amount,
+            from = windowStart,
+            to = windowEnd,
+        )
+
+        if (existing != null) {
+            // Merge: add source, upgrade confidence
+            val merged = existing.copy(
+                sources = (existing.sources + parsed.source).distinct(),
+                confidence = PendingTransactionConfidence.HIGH,
+            )
+            repository.update(merged)
+        } else {
+            // New entry
+            repository.add(
+                PendingTransaction(
+                    amount = parsed.amount,
+                    description = parsed.description,
+                    detectedAt = parsed.receivedAt,
+                    sources = listOf(parsed.source),
+                    confidence = PendingTransactionConfidence.LOW,
+                )
+            )
+        }
+    }
+
+    companion object {
+        /** Time window within which two notifications for the same amount are considered duplicates. */
+        const val DEDUPLICATION_WINDOW_MINUTES = 2L
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/helper/NotificationHelper.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/helper/NotificationHelper.kt
@@ -9,22 +9,29 @@ import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import fr.laforge.benoist.financialmanager.R
-import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
 import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationHelper
 import fr.laforge.benoist.financialmanager.infrastructure.notification.BalanceNotifier
+import fr.laforge.benoist.financialmanager.infrastructure.notification.NotificationParserFactory
 
 /**
  * Concrete implementation of [NotificationHelper] (domain parsing port) and
  * [BalanceNotifier] (infrastructure display port).
  *
- * Combining both in one class keeps the Android notification channel setup in a single
- * place while respecting the interface separation: callers that only need parsing depend
- * on [NotificationHelper]; callers that only need display depend on [BalanceNotifier].
+ * Parsing is fully delegated to [factory], which selects the correct parser at runtime
+ * (Google Pay format, bank proprietary format, etc.) and returns a [ParsedNotification]
+ * that preserves the originating source for the deduplication pipeline.
  *
  * @property context Application [Context] required for notification channel creation
  *   and permission checks.
+ * @property factory Parser registry for all supported notification formats.
+ *   Defaults to a [NotificationParserFactory] with the standard set of parsers; can be
+ *   overridden in tests to inject a controlled factory.
  */
-class NotificationHelperImpl(private val context: Context) : NotificationHelper, BalanceNotifier {
+class NotificationHelperImpl(
+    private val context: Context,
+    private val factory: NotificationParserFactory = NotificationParserFactory(),
+) : NotificationHelper, BalanceNotifier {
 
     override fun showBalanceUpdate(newBalance: Float) {
         // ⚠️ CRITICAL: Changed ID to force Android to register new Priority settings
@@ -60,36 +67,11 @@ class NotificationHelperImpl(private val context: Context) : NotificationHelper,
         }
     }
 
-    override fun isTransaction(notificationMessage: String): Result<Boolean> {
-        return if (notificationMessage.contains(EURO_SYMBOL)) {
-            Result.success(true)
-        } else {
-            Result.success(false)
-        }
-    }
+    override fun isTransaction(notificationMessage: String): Result<Boolean> =
+        Result.success(factory.canParse(notificationMessage))
 
-    override fun parseNotificationMessage(notificationTitle: String, notificationMessage: String): Result<Transaction> {
-        val split = notificationMessage.split(EURO_SYMBOL)
-
-        if (split.size <= 1) {
-            return Result.failure(Exception("No amount found"))
-        }
-
-        val amount = split[0].trim().replace(',', '.').toFloat()
-
-        return if (amount < 0) {
-            Result.failure(Exception("Negative amount"))
-        } else {
-            Result.success(
-                Transaction(
-                    amount = amount,
-                    description = notificationTitle
-                )
-            )
-        }
-    }
-
-    companion object {
-        private const val EURO_SYMBOL = '€'
-    }
+    override fun parseToPending(
+        notificationTitle: String,
+        notificationMessage: String,
+    ): Result<ParsedNotification> = factory.parse(notificationTitle, notificationMessage)
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/BankNotificationParser.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/BankNotificationParser.kt
@@ -1,0 +1,51 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationParser
+
+/**
+ * Parses proprietary bank (Samsung Wallet) notifications.
+ *
+ * ## Format
+ * - **Title**: not used for parsing
+ * - **Body**: `"{description}€{amount}"` — description is **before** `€`,
+ *   amount is **after** `€`, comma as decimal separator
+ *   (e.g. `"Starbucks€12,50"`)
+ *
+ * Detection: the substring before `€` (trimmed) is non-numeric text.
+ */
+class BankNotificationParser : NotificationParser {
+
+    override fun canParse(body: String): Boolean {
+        if (!body.contains(EURO_SYMBOL)) return false
+        val beforeEuro = body.substringBefore(EURO_SYMBOL).trim()
+        return beforeEuro.replace(',', '.').toFloatOrNull() == null
+    }
+
+    override fun parse(title: String, body: String): Result<ParsedNotification> {
+        val parts = body.split(EURO_SYMBOL)
+        if (parts.size < 2) {
+            return Result.failure(IllegalArgumentException("Missing amount in: $body"))
+        }
+
+        val description = parts[0].trim()
+        val amountStr = parts[1].trim().replace(',', '.')
+        val amount = amountStr.toFloatOrNull()
+            ?: return Result.failure(IllegalArgumentException("Cannot parse amount from: $body"))
+
+        if (amount < 0) return Result.failure(IllegalArgumentException("Negative amount: $amount"))
+
+        return Result.success(
+            ParsedNotification(
+                amount = amount,
+                description = description,
+                source = NotificationSource.BANK,
+            )
+        )
+    }
+
+    companion object {
+        private const val EURO_SYMBOL = '€'
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/GooglePayNotificationParser.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/GooglePayNotificationParser.kt
@@ -1,0 +1,43 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationParser
+
+/**
+ * Parses Google Pay / Google Wallet notifications.
+ *
+ * ## Format
+ * - **Title**: merchant name (e.g. `"DUMMY VENDOR"`)
+ * - **Body**: `"{amount} € {any text}"` — amount is **before** `€`, comma as decimal separator
+ *   (e.g. `"10,00 € dummy string"`)
+ *
+ * Detection: the substring before `€` (trimmed) is numeric.
+ */
+class GooglePayNotificationParser : NotificationParser {
+
+    override fun canParse(body: String): Boolean {
+        val beforeEuro = body.substringBefore(EURO_SYMBOL).trim()
+        return beforeEuro.replace(',', '.').toFloatOrNull() != null
+    }
+
+    override fun parse(title: String, body: String): Result<ParsedNotification> {
+        val amountStr = body.substringBefore(EURO_SYMBOL).trim().replace(',', '.')
+        val amount = amountStr.toFloatOrNull()
+            ?: return Result.failure(IllegalArgumentException("Cannot parse amount from: $body"))
+
+        if (amount < 0) return Result.failure(IllegalArgumentException("Negative amount: $amount"))
+
+        return Result.success(
+            ParsedNotification(
+                amount = amount,
+                description = title,
+                source = NotificationSource.GOOGLE_PAY,
+            )
+        )
+    }
+
+    companion object {
+        private const val EURO_SYMBOL = '€'
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/NotificationParserFactory.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/notification/NotificationParserFactory.kt
@@ -1,0 +1,44 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.usecase.notification.NotificationParser
+
+/**
+ * Selects the correct [NotificationParser] for a given notification body and delegates parsing.
+ *
+ * Parsers are evaluated in priority order; the first one whose [NotificationParser.canParse]
+ * returns `true` is used. [GooglePayNotificationParser] is checked first because its format
+ * (numeric amount before `€`) is more specific than the bank format.
+ *
+ * @property parsers Ordered list of available parsers. Defaults to the two known implementations.
+ *
+ * @note Injecting [parsers] as a constructor parameter makes the factory fully testable
+ *   without relying on the Android context.
+ */
+class NotificationParserFactory(
+    private val parsers: List<NotificationParser> = listOf(
+        GooglePayNotificationParser(),
+        BankNotificationParser(),
+    )
+) {
+    /**
+     * Returns `true` if at least one registered parser can handle [body].
+     *
+     * @param body The raw notification body text.
+     */
+    fun canParse(body: String): Boolean = parsers.any { it.canParse(body) }
+
+    /**
+     * Parses [body] using the first matching parser.
+     *
+     * @param title The notification title.
+     * @param body  The notification body.
+     * @return [Result.success] with a [ParsedNotification], or [Result.failure] if no
+     *   parser matched or parsing failed.
+     */
+    fun parse(title: String, body: String): Result<ParsedNotification> {
+        val parser = parsers.firstOrNull { it.canParse(body) }
+            ?: return Result.failure(IllegalArgumentException("No parser found for: $body"))
+        return parser.parse(title, body)
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/RoomPendingTransactionRepository.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/RoomPendingTransactionRepository.kt
@@ -1,0 +1,47 @@
+package fr.laforge.benoist.financialmanager.infrastructure.repository
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+import fr.laforge.benoist.financialmanager.domain.util.toMilliseconds
+import fr.laforge.benoist.financialmanager.infrastructure.repository.dao.PendingTransactionDao
+import fr.laforge.benoist.financialmanager.infrastructure.repository.entity.PendingTransactionEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Room-backed implementation of [PendingTransactionRepository].
+ *
+ * All mapping between domain models and Room entities is performed here,
+ * keeping the domain layer free of persistence concerns.
+ *
+ * @property dao The [PendingTransactionDao] used for all database operations.
+ */
+class RoomPendingTransactionRepository(
+    private val dao: PendingTransactionDao,
+) : PendingTransactionRepository {
+
+    override suspend fun add(pendingTransaction: PendingTransaction) {
+        dao.insert(PendingTransactionEntity.fromModel(pendingTransaction))
+    }
+
+    override suspend fun update(pendingTransaction: PendingTransaction) {
+        dao.update(PendingTransactionEntity.fromModel(pendingTransaction))
+    }
+
+    override fun getAllPending(): Flow<List<PendingTransaction>> =
+        dao.getAllPending().map { entities -> entities.map { it.toModel() } }
+
+    override suspend fun findPendingByAmountInWindow(
+        amount: Float,
+        from: LocalDateTime,
+        to: LocalDateTime,
+    ): PendingTransaction? =
+        dao.findPendingByAmountInWindow(amount, from.toMilliseconds(), to.toMilliseconds())?.toModel()
+
+    override suspend fun updateStatus(id: UUID, status: PendingTransactionStatus) {
+        dao.updateStatus(id.toString(), status.name)
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/converters/NotificationSourceConverters.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/converters/NotificationSourceConverters.kt
@@ -1,0 +1,26 @@
+package fr.laforge.benoist.financialmanager.infrastructure.repository.converters
+
+import androidx.room.TypeConverter
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+
+/**
+ * Room [TypeConverter] for [List]<[NotificationSource]>.
+ *
+ * Serialises the list as a comma-separated string of enum names
+ * (e.g. `"GOOGLE_PAY,BANK"`) for storage in a single TEXT column.
+ */
+class NotificationSourceConverters {
+
+    @TypeConverter
+    fun fromString(value: String?): List<NotificationSource> {
+        if (value.isNullOrBlank()) return emptyList()
+        return value.split(",").mapNotNull { name ->
+            NotificationSource.entries.firstOrNull { it.name == name }
+        }
+    }
+
+    @TypeConverter
+    fun toCommaSeparatedString(sources: List<NotificationSource>?): String {
+        return sources?.joinToString(",") { it.name } ?: ""
+    }
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/dao/PendingTransactionDao.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/dao/PendingTransactionDao.kt
@@ -1,0 +1,55 @@
+package fr.laforge.benoist.financialmanager.infrastructure.repository.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import fr.laforge.benoist.financialmanager.infrastructure.repository.entity.PendingTransactionEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Room DAO for [PendingTransactionEntity] persistence.
+ *
+ * All mutating functions are intentionally non-suspend to avoid a Room KSP code-generation
+ * variance bug (Continuation<T> vs Continuation<? super T>).  Callers in
+ * [fr.laforge.benoist.financialmanager.infrastructure.repository.RoomPendingTransactionRepository]
+ * run them inside a coroutine dispatcher, so no blocking occurs on the main thread.
+ */
+@Dao
+interface PendingTransactionDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insert(entity: PendingTransactionEntity): Long
+
+    @Update
+    fun update(entity: PendingTransactionEntity): Int
+
+    @Query("SELECT * FROM pending_transaction WHERE status = 'PENDING' ORDER BY detected_at DESC")
+    fun getAllPending(): Flow<List<PendingTransactionEntity>>
+
+    /**
+     * Finds a PENDING transaction with the given [amount] whose
+     * [detectedAt][PendingTransactionEntity.detectedAt] falls within [[fromEpochMs], [toEpochMs]].
+     *
+     * Parameters are epoch-milliseconds (UTC) to avoid binding [java.time.LocalDateTime] directly
+     * in a @Query — TypeConverters apply to entity columns, not query bind parameters, in this
+     * version of Room KSP.
+     */
+    @Query("""
+        SELECT * FROM pending_transaction
+        WHERE status = 'PENDING'
+        AND amount = :amount
+        AND detected_at >= :fromEpochMs
+        AND detected_at <= :toEpochMs
+        LIMIT 1
+    """)
+    fun findPendingByAmountInWindow(
+        amount: Float,
+        fromEpochMs: Long,
+        toEpochMs: Long,
+    ): PendingTransactionEntity?
+
+    @Query("UPDATE pending_transaction SET status = :status WHERE id = :id")
+    fun updateStatus(id: String, status: String): Int
+}

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/database/AppDatabase.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/database/AppDatabase.kt
@@ -4,19 +4,46 @@ import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import fr.laforge.benoist.financialmanager.infrastructure.repository.converters.LocalDateTimeConverters
+import fr.laforge.benoist.financialmanager.infrastructure.repository.converters.NotificationSourceConverters
 import fr.laforge.benoist.financialmanager.infrastructure.repository.dao.FinancialInputDao
+import fr.laforge.benoist.financialmanager.infrastructure.repository.dao.PendingTransactionDao
+import fr.laforge.benoist.financialmanager.infrastructure.repository.entity.PendingTransactionEntity
 import fr.laforge.benoist.financialmanager.infrastructure.repository.entity.TransactionEntity
 
 @Database(
-    version = 2,
-    entities = [TransactionEntity::class],
+    version = 3,
+    entities = [TransactionEntity::class, PendingTransactionEntity::class],
     autoMigrations = [
-        AutoMigration (from = 1, to = 2)
+        AutoMigration(from = 1, to = 2),
     ],
     exportSchema = true
 )
-@TypeConverters(LocalDateTimeConverters::class)
+@TypeConverters(LocalDateTimeConverters::class, NotificationSourceConverters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun getFinancialInputDao(): FinancialInputDao
+    abstract fun getPendingTransactionDao(): PendingTransactionDao
+
+    companion object {
+        /** Adds the pending_transaction table introduced in schema version 3. */
+        val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `pending_transaction` (
+                        `id` TEXT NOT NULL PRIMARY KEY,
+                        `amount` REAL NOT NULL,
+                        `description` TEXT NOT NULL,
+                        `detected_at` INTEGER NOT NULL,
+                        `sources` TEXT NOT NULL,
+                        `confidence` TEXT NOT NULL,
+                        `status` TEXT NOT NULL
+                    )
+                    """.trimIndent()
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/entity/PendingTransactionEntity.kt
+++ b/app/src/main/java/fr/laforge/benoist/financialmanager/infrastructure/repository/entity/PendingTransactionEntity.kt
@@ -1,0 +1,53 @@
+package fr.laforge.benoist.financialmanager.infrastructure.repository.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Room entity representing a [PendingTransaction] in the local database.
+ *
+ * [id] is stored as a [String] because Room has no native UUID column type.
+ * The [sources] list is serialised by [fr.laforge.benoist.financialmanager.infrastructure.repository.converters.NotificationSourceConverters].
+ */
+@Entity(tableName = "pending_transaction")
+data class PendingTransactionEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "id") val id: String,
+    @ColumnInfo(name = "amount") val amount: Float,
+    @ColumnInfo(name = "description") val description: String,
+    @ColumnInfo(name = "detected_at") val detectedAt: LocalDateTime,
+    @ColumnInfo(name = "sources") val sources: List<NotificationSource>,
+    @ColumnInfo(name = "confidence") val confidence: PendingTransactionConfidence,
+    @ColumnInfo(name = "status") val status: PendingTransactionStatus,
+) {
+    /** Converts this entity to its domain representation. */
+    fun toModel(): PendingTransaction = PendingTransaction(
+        id = UUID.fromString(id),
+        amount = amount,
+        description = description,
+        detectedAt = detectedAt,
+        sources = sources,
+        confidence = confidence,
+        status = status,
+    )
+
+    companion object {
+        /** Creates a [PendingTransactionEntity] from a domain [PendingTransaction]. */
+        fun fromModel(model: PendingTransaction) = PendingTransactionEntity(
+            id = model.id.toString(),
+            amount = model.amount,
+            description = model.description,
+            detectedAt = model.detectedAt,
+            sources = model.sources,
+            confidence = model.confidence,
+            status = model.status,
+        )
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ConfirmPendingTransactionUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ConfirmPendingTransactionUseCaseTest.kt
@@ -1,0 +1,72 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.coEvery
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import java.util.UUID
+
+class ConfirmPendingTransactionUseCaseTest {
+
+    private val repository = mockk<PendingTransactionRepository>(relaxed = true)
+    private val createTransactionUseCase = mockk<CreateTransactionUseCase>(relaxed = true)
+    private val useCase = ConfirmPendingTransactionUseCase(repository, createTransactionUseCase)
+
+    private val pending = PendingTransaction(
+        id = UUID.randomUUID(),
+        amount = 25.00f,
+        description = "Supermarket",
+        sources = listOf(NotificationSource.BANK),
+        confidence = PendingTransactionConfidence.LOW,
+    )
+
+    // --- Happy path ---
+
+    @Test
+    fun `updates status to CONFIRMED and creates transaction`() = runTest {
+        // --- Act ---
+        useCase(pending)
+
+        // --- Assert ---
+        coVerify(exactly = 1) {
+            repository.updateStatus(pending.id, PendingTransactionStatus.CONFIRMED)
+        }
+        coVerify(exactly = 1) { createTransactionUseCase(any()) }
+    }
+
+    @Test
+    fun `created transaction carries amount and description from pending entry`() = runTest {
+        // --- Arrange ---
+        val slot = slot<Transaction>()
+        coEvery { createTransactionUseCase(capture(slot)) } returns true
+
+        // --- Act ---
+        useCase(pending)
+
+        // --- Assert ---
+        slot.captured.amount shouldBeEqualTo 25.00f
+        slot.captured.description shouldBeEqualTo "Supermarket"
+    }
+
+    // --- Edge case ---
+
+    @Test
+    fun `does not create transaction when repository update throws`() = runTest {
+        // --- Arrange ---
+        coEvery { repository.updateStatus(any(), any()) } throws RuntimeException("DB error")
+
+        // --- Act & Assert ---
+        try { useCase(pending) } catch (_: RuntimeException) {}
+        coVerify(exactly = 0) { createTransactionUseCase(any()) }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/CreateTransactionFromNotificationUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/CreateTransactionFromNotificationUseCaseTest.kt
@@ -1,7 +1,8 @@
 package fr.laforge.benoist.financialmanager.domain.usecase.notification
 
-import fr.laforge.benoist.financialmanager.domain.model.transaction.Transaction
-import fr.laforge.benoist.financialmanager.domain.usecase.CreateTransactionUseCase
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -13,76 +14,78 @@ import org.junit.Test
 
 class CreateTransactionFromNotificationUseCaseTest {
 
-    private val createTransactionUseCase = mockk<CreateTransactionUseCase>(relaxed = true)
+    private val pendingTransactionRepository = mockk<PendingTransactionRepository>(relaxed = true)
     private val notificationHelper = mockk<NotificationHelper>()
     private val testDispatcher = StandardTestDispatcher()
 
-    private val useCase = CreateTransactionFromNotificationUseCase(
-        createTransactionUseCase = createTransactionUseCase,
-        notificationHelper = notificationHelper,
-        dispatcher = testDispatcher
+    private val processIncomingNotificationUseCase = ProcessIncomingNotificationUseCase(
+        repository = pendingTransactionRepository,
     )
 
-    private val dummyTransaction = Transaction(uid = 1, amount = 50f, description = "Test")
+    private val useCase = CreateTransactionFromNotificationUseCase(
+        processIncomingNotificationUseCase = processIncomingNotificationUseCase,
+        notificationHelper = notificationHelper,
+        dispatcher = testDispatcher,
+    )
+
+    private val dummyParsed = ParsedNotification(
+        amount = 50f,
+        description = "Test Merchant",
+        source = NotificationSource.GOOGLE_PAY,
+    )
 
     @Test
-    fun `invoke creates transaction and returns true when notification is valid`() = runTest(testDispatcher) {
+    fun `invoke stages pending transaction and returns true when notification is valid`() = runTest(testDispatcher) {
         // --- Arrange ---
+        every { notificationHelper.isTransaction("€ 50.00 - Merchant") } returns Result.success(true)
         every {
-            notificationHelper.isTransaction("€ 50.00 - Merchant")
-        } returns Result.success(true)
-        every {
-            notificationHelper.parseNotificationMessage("Merchant", "€ 50.00 - Merchant")
-        } returns Result.success(dummyTransaction)
-        coEvery { createTransactionUseCase(dummyTransaction) } returns true
+            notificationHelper.parseToPending("Merchant", "€ 50.00 - Merchant")
+        } returns Result.success(dummyParsed)
+        coEvery { pendingTransactionRepository.findPendingByAmountInWindow(any(), any(), any()) } returns null
 
         // --- Act ---
         val result = useCase(
             notificationTitle = "Merchant",
-            notificationMessage = "€ 50.00 - Merchant"
+            notificationMessage = "€ 50.00 - Merchant",
         )
 
         // --- Assert ---
         result shouldBeEqualTo true
-        coVerify(exactly = 1) { createTransactionUseCase(dummyTransaction) }
+        coVerify(exactly = 1) { pendingTransactionRepository.add(any()) }
     }
 
     @Test
-    fun `invoke returns false and skips creation when notification is not a transaction`() = runTest(testDispatcher) {
+    fun `invoke returns false and skips staging when notification is not a transaction`() = runTest(testDispatcher) {
         // --- Arrange ---
-        every {
-            notificationHelper.isTransaction(any())
-        } returns Result.success(false)
+        every { notificationHelper.isTransaction(any()) } returns Result.success(false)
 
         // --- Act ---
         val result = useCase(
             notificationTitle = "News App",
-            notificationMessage = "Breaking news: markets hit record"
+            notificationMessage = "Breaking news: markets hit record",
         )
 
         // --- Assert ---
         result shouldBeEqualTo false
-        coVerify(exactly = 0) { createTransactionUseCase(any()) }
+        coVerify(exactly = 0) { pendingTransactionRepository.add(any()) }
     }
 
     @Test
-    fun `invoke returns false and skips creation when parsing fails`() = runTest(testDispatcher) {
+    fun `invoke returns false and skips staging when parsing fails`() = runTest(testDispatcher) {
         // --- Arrange ---
+        every { notificationHelper.isTransaction(any()) } returns Result.success(true)
         every {
-            notificationHelper.isTransaction(any())
-        } returns Result.success(true)
-        every {
-            notificationHelper.parseNotificationMessage(any(), any())
-        } returns Result.failure(IllegalArgumentException("Cannot parse amount"))
+            notificationHelper.parseToPending(any(), any())
+        } returns Result.failure(IllegalArgumentException("No parser matched"))
 
         // --- Act ---
         val result = useCase(
             notificationTitle = "Bank",
-            notificationMessage = "Malformed message"
+            notificationMessage = "Malformed message",
         )
 
         // --- Assert ---
         result shouldBeEqualTo false
-        coVerify(exactly = 0) { createTransactionUseCase(any()) }
+        coVerify(exactly = 0) { pendingTransactionRepository.add(any()) }
     }
 }

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/DismissPendingTransactionUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/DismissPendingTransactionUseCaseTest.kt
@@ -1,0 +1,61 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.util.UUID
+
+class DismissPendingTransactionUseCaseTest {
+
+    private val repository = mockk<PendingTransactionRepository>(relaxed = true)
+    private val useCase = DismissPendingTransactionUseCase(repository)
+
+    private val pending = PendingTransaction(
+        id = UUID.randomUUID(),
+        amount = 8.50f,
+        description = "Coffee",
+        sources = listOf(NotificationSource.GOOGLE_PAY),
+        confidence = PendingTransactionConfidence.HIGH,
+    )
+
+    // --- Happy path ---
+
+    @Test
+    fun `updates status to DISMISSED`() = runTest {
+        // --- Act ---
+        useCase(pending)
+
+        // --- Assert ---
+        coVerify(exactly = 1) {
+            repository.updateStatus(pending.id, PendingTransactionStatus.DISMISSED)
+        }
+    }
+
+    // --- Edge cases ---
+
+    @Test
+    fun `does not call updateStatus with CONFIRMED`() = runTest {
+        // --- Act ---
+        useCase(pending)
+
+        // --- Assert ---
+        coVerify(exactly = 0) {
+            repository.updateStatus(any(), PendingTransactionStatus.CONFIRMED)
+        }
+    }
+
+    @Test
+    fun `calls updateStatus exactly once even for HIGH confidence entry`() = runTest {
+        // --- Act ---
+        useCase(pending.copy(confidence = PendingTransactionConfidence.HIGH))
+
+        // --- Assert ---
+        coVerify(exactly = 1) { repository.updateStatus(any(), any()) }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationHelperTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/NotificationHelperTest.kt
@@ -1,44 +1,81 @@
 package fr.laforge.benoist.financialmanager.domain.usecase.notification
 
 import android.content.Context
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
 import fr.laforge.benoist.financialmanager.infrastructure.helper.NotificationHelperImpl
+import fr.laforge.benoist.financialmanager.infrastructure.notification.NotificationParserFactory
 import io.mockk.mockk
 import org.amshove.kluent.`should be`
 import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 
 class NotificationHelperTest {
     private val context: Context = mockk()
-    private val notificationHelper = NotificationHelperImpl(context)
+    private val notificationHelper = NotificationHelperImpl(context, NotificationParserFactory())
+
+    // --- isTransaction ---
 
     @Test
-    fun `invoke should return correct Transaction when receiving a google wallet notification`() {
-        // --- Arrange ---
-        val notificationTitle = "DUMMY VENDOR"
-        val notificationMessage = "10,00 € dummy string"
-
-        // --- Act ---
-        val result = notificationHelper.parseNotificationMessage(notificationTitle, notificationMessage)
-
-        // --- Assert ---
+    fun `isTransaction returns true for Google Pay notification body`() {
+        val result = notificationHelper.isTransaction("10,00 € dummy string")
         result.isSuccess `should be` true
-        val transaction = result.getOrNull()
-        transaction?.amount `should be equal to` 10.00f
-        transaction?.description `should be` notificationTitle
+        result.getOrNull() `should be equal to` true
     }
 
     @Test
-    fun `invoke should return failure when receiving negative amount notification`() {
-        // --- Arrange ---
-        val notificationTitle = "DUMMY VENDOR"
-        val notificationMessage = "-10,00€ dummy string"
+    fun `isTransaction returns true for bank notification body`() {
+        val result = notificationHelper.isTransaction("DUMMY VENDOR €10.00")
+        result.isSuccess `should be` true
+        result.getOrNull() `should be equal to` true
+    }
 
-        // --- Act ---
-        val result = notificationHelper.parseNotificationMessage(notificationTitle, notificationMessage)
+    @Test
+    fun `isTransaction returns false when body contains no euro sign`() {
+        val result = notificationHelper.isTransaction("Breaking news: markets soar")
+        result.isSuccess `should be` true
+        result.getOrNull() `should be equal to` false
+    }
 
-        // --- Assert ---
+    // --- parseToPending ---
+
+    @Test
+    fun `parseToPending returns ParsedNotification for Google Pay format`() {
+        // Google Pay format: numeric amount before €, merchant in title
+        val result = notificationHelper.parseToPending(
+            notificationTitle = "DUMMY VENDOR",
+            notificationMessage = "10,00 € dummy string",
+        )
+
+        result.isSuccess `should be` true
+        val parsed = result.getOrNull()!!
+        parsed.amount shouldBeEqualTo 10.00f
+        parsed.description `should be equal to` "DUMMY VENDOR"
+        parsed.source `should be equal to` NotificationSource.GOOGLE_PAY
+    }
+
+    @Test
+    fun `parseToPending returns ParsedNotification for bank format`() {
+        // Bank format: description before €, amount after €
+        val result = notificationHelper.parseToPending(
+            notificationTitle = "BankApp",
+            notificationMessage = "DUMMY VENDOR €10.00",
+        )
+
+        result.isSuccess `should be` true
+        val parsed = result.getOrNull()!!
+        parsed.amount shouldBeEqualTo 10.00f
+        parsed.description `should be equal to` "DUMMY VENDOR"
+        parsed.source `should be equal to` NotificationSource.BANK
+    }
+
+    @Test
+    fun `parseToPending returns failure when body has no parseable format`() {
+        val result = notificationHelper.parseToPending(
+            notificationTitle = "App",
+            notificationMessage = "No amount here",
+        )
+
         result.isFailure `should be` true
-        val exception = result.exceptionOrNull()
-        exception?.message `should be` "Negative amount"
     }
 }

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCaseTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/domain/usecase/notification/ProcessIncomingNotificationUseCaseTest.kt
@@ -1,0 +1,137 @@
+package fr.laforge.benoist.financialmanager.domain.usecase.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import fr.laforge.benoist.financialmanager.domain.model.notification.ParsedNotification
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransaction
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionConfidence
+import fr.laforge.benoist.financialmanager.domain.model.notification.PendingTransactionStatus
+import fr.laforge.benoist.financialmanager.domain.repository.PendingTransactionRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
+import org.junit.Test
+import java.time.LocalDateTime
+
+class ProcessIncomingNotificationUseCaseTest {
+
+    private val repository = mockk<PendingTransactionRepository>(relaxed = true)
+    private val useCase = ProcessIncomingNotificationUseCase(repository)
+
+    private val baseTime = LocalDateTime.of(2026, 3, 1, 10, 0, 0)
+
+    // --- Happy path: new entry ---
+
+    @Test
+    fun `adds new PendingTransaction when no match exists in window`() = runTest {
+        // --- Arrange ---
+        val parsed = ParsedNotification(
+            amount = 12.50f,
+            description = "Starbucks",
+            source = NotificationSource.BANK,
+            receivedAt = baseTime,
+        )
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns null
+        val slot = slot<PendingTransaction>()
+        coEvery { repository.add(capture(slot)) } returns Unit
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        coVerify(exactly = 1) { repository.add(any()) }
+        slot.captured.amount shouldBeEqualTo 12.50f
+        slot.captured.description shouldBeEqualTo "Starbucks"
+        slot.captured.sources shouldBeEqualTo listOf(NotificationSource.BANK)
+        slot.captured.confidence shouldBeEqualTo PendingTransactionConfidence.LOW
+        slot.captured.status shouldBeEqualTo PendingTransactionStatus.PENDING
+    }
+
+    // --- Deduplication: merge ---
+
+    @Test
+    fun `merges into existing entry and upgrades confidence to HIGH when match found`() = runTest {
+        // --- Arrange ---
+        val existing = PendingTransaction(
+            amount = 12.50f,
+            description = "Starbucks",
+            detectedAt = baseTime.minusMinutes(1),
+            sources = listOf(NotificationSource.GOOGLE_PAY),
+            confidence = PendingTransactionConfidence.LOW,
+        )
+        val parsed = ParsedNotification(
+            amount = 12.50f,
+            description = "Starbucks",
+            source = NotificationSource.BANK,
+            receivedAt = baseTime,
+        )
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns existing
+        val slot = slot<PendingTransaction>()
+        coEvery { repository.update(capture(slot)) } returns Unit
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        coVerify(exactly = 0) { repository.add(any()) }
+        coVerify(exactly = 1) { repository.update(any()) }
+        slot.captured.sources shouldContain NotificationSource.GOOGLE_PAY
+        slot.captured.sources shouldContain NotificationSource.BANK
+        slot.captured.confidence shouldBeEqualTo PendingTransactionConfidence.HIGH
+    }
+
+    // --- Edge case: same source does not duplicate ---
+
+    @Test
+    fun `does not duplicate source when same source matches within window`() = runTest {
+        // --- Arrange ---
+        val existing = PendingTransaction(
+            amount = 5.00f,
+            description = "Coffee",
+            detectedAt = baseTime,
+            sources = listOf(NotificationSource.BANK),
+            confidence = PendingTransactionConfidence.LOW,
+        )
+        val parsed = ParsedNotification(
+            amount = 5.00f,
+            description = "Coffee",
+            source = NotificationSource.BANK,
+            receivedAt = baseTime.plusSeconds(30),
+        )
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns existing
+        val slot = slot<PendingTransaction>()
+        coEvery { repository.update(capture(slot)) } returns Unit
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        slot.captured.sources.size shouldBeEqualTo 1
+        slot.captured.sources shouldBeEqualTo listOf(NotificationSource.BANK)
+    }
+
+    // --- Edge case: outside window creates new entry ---
+
+    @Test
+    fun `creates new entry when matching amount is outside deduplication window`() = runTest {
+        // --- Arrange ---
+        val parsed = ParsedNotification(
+            amount = 20.00f,
+            description = "Restaurant",
+            source = NotificationSource.GOOGLE_PAY,
+            receivedAt = baseTime,
+        )
+        // Repository returns null because no match in window
+        coEvery { repository.findPendingByAmountInWindow(any(), any(), any()) } returns null
+
+        // --- Act ---
+        useCase(parsed)
+
+        // --- Assert ---
+        coVerify(exactly = 1) { repository.add(any()) }
+        coVerify(exactly = 0) { repository.update(any()) }
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/BankNotificationParserTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/BankNotificationParserTest.kt
@@ -1,0 +1,61 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should be equal to`
+import org.junit.Test
+
+class BankNotificationParserTest {
+
+    private val parser = BankNotificationParser()
+
+    // --- canParse ---
+
+    @Test
+    fun `canParse returns true for valid bank format`() {
+        parser.canParse("Starbucks€12,50") `should be` true
+    }
+
+    @Test
+    fun `canParse returns false for Google Pay format`() {
+        parser.canParse("10,00 € dummy string") `should be` false
+    }
+
+    @Test
+    fun `canParse returns false when no euro symbol present`() {
+        parser.canParse("no euro here") `should be` false
+    }
+
+    // --- parse: happy path ---
+
+    @Test
+    fun `parse extracts description and amount correctly`() {
+        val result = parser.parse("ignored title", "Starbucks€12,50")
+        result.isSuccess `should be` true
+        result.getOrNull()?.amount `should be equal to` 12.50f
+        result.getOrNull()?.description `should be equal to` "Starbucks"
+        result.getOrNull()?.source `should be equal to` NotificationSource.BANK
+    }
+
+    @Test
+    fun `parse trims whitespace from description and amount`() {
+        val result = parser.parse("ignored", " Coffee Shop €3,00")
+        result.isSuccess `should be` true
+        result.getOrNull()?.description `should be equal to` "Coffee Shop"
+        result.getOrNull()?.amount `should be equal to` 3.00f
+    }
+
+    // --- parse: edge cases ---
+
+    @Test
+    fun `parse returns failure for negative amount`() {
+        val result = parser.parse("ignored", "Starbucks€-12,50")
+        result.isFailure `should be` true
+    }
+
+    @Test
+    fun `parse returns failure when amount is missing`() {
+        val result = parser.parse("ignored", "NoAmountHere")
+        result.isFailure `should be` true
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/GooglePayNotificationParserTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/GooglePayNotificationParserTest.kt
@@ -1,0 +1,60 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should be equal to`
+import org.junit.Test
+
+class GooglePayNotificationParserTest {
+
+    private val parser = GooglePayNotificationParser()
+
+    // --- canParse ---
+
+    @Test
+    fun `canParse returns true for valid Google Pay format`() {
+        parser.canParse("10,00 € dummy string") `should be` true
+    }
+
+    @Test
+    fun `canParse returns false for bank format`() {
+        parser.canParse("Starbucks€12,50") `should be` false
+    }
+
+    @Test
+    fun `canParse returns false when no euro symbol present`() {
+        parser.canParse("no euro here") `should be` false
+    }
+
+    // --- parse: happy path ---
+
+    @Test
+    fun `parse extracts amount and title correctly`() {
+        val result = parser.parse("DUMMY VENDOR", "10,00 € dummy string")
+        result.isSuccess `should be` true
+        result.getOrNull()?.amount `should be equal to` 10.00f
+        result.getOrNull()?.description `should be equal to` "DUMMY VENDOR"
+        result.getOrNull()?.source `should be equal to` NotificationSource.GOOGLE_PAY
+    }
+
+    @Test
+    fun `parse handles amount without trailing text`() {
+        val result = parser.parse("Shop", "5,99€")
+        result.isSuccess `should be` true
+        result.getOrNull()?.amount `should be equal to` 5.99f
+    }
+
+    // --- parse: edge cases ---
+
+    @Test
+    fun `parse returns failure for negative amount`() {
+        val result = parser.parse("VENDOR", "-10,00 € refund")
+        result.isFailure `should be` true
+    }
+
+    @Test
+    fun `parse returns failure when amount is not parseable`() {
+        val result = parser.parse("VENDOR", "abc€rest")
+        result.isFailure `should be` true
+    }
+}

--- a/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/NotificationParserFactoryTest.kt
+++ b/app/src/test/java/fr/laforge/benoist/financialmanager/infrastructure/notification/NotificationParserFactoryTest.kt
@@ -1,0 +1,50 @@
+package fr.laforge.benoist.financialmanager.infrastructure.notification
+
+import fr.laforge.benoist.financialmanager.domain.model.notification.NotificationSource
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should be equal to`
+import org.junit.Test
+
+class NotificationParserFactoryTest {
+
+    private val factory = NotificationParserFactory()
+
+    // --- canParse ---
+
+    @Test
+    fun `canParse returns true for Google Pay format`() {
+        factory.canParse("10,00 € some text") `should be` true
+    }
+
+    @Test
+    fun `canParse returns true for bank format`() {
+        factory.canParse("Starbucks€12,50") `should be` true
+    }
+
+    @Test
+    fun `canParse returns false for unrecognised format`() {
+        factory.canParse("no euro sign here") `should be` false
+    }
+
+    // --- parse: routes to correct parser ---
+
+    @Test
+    fun `parse routes Google Pay notification to GooglePayNotificationParser`() {
+        val result = factory.parse("VENDOR", "10,00 € some text")
+        result.isSuccess `should be` true
+        result.getOrNull()?.source `should be equal to` NotificationSource.GOOGLE_PAY
+    }
+
+    @Test
+    fun `parse routes bank notification to BankNotificationParser`() {
+        val result = factory.parse("ignored", "Starbucks€12,50")
+        result.isSuccess `should be` true
+        result.getOrNull()?.source `should be equal to` NotificationSource.BANK
+    }
+
+    @Test
+    fun `parse returns failure for unrecognised format`() {
+        val result = factory.parse("title", "no euro sign here")
+        result.isFailure `should be` true
+    }
+}


### PR DESCRIPTION
## Summary

- **repositoryModule**: register `AppDatabase` as a single, passing `MIGRATION_2_3` (replacing the old pattern that built the DB and immediately discarded the reference); expose `FinancialInputDao` and `PendingTransactionDao` as separate singletons; bind `PendingTransactionRepository` → `RoomPendingTransactionRepository`
- **useCaseModule**: register `ProcessIncomingNotificationUseCase`, `ConfirmPendingTransactionUseCase`, `DismissPendingTransactionUseCase`

## Test plan

- [ ] `./gradlew assembleDebug` passes ✅
- [ ] Install on device — no Koin injection errors at startup or during notification handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)